### PR TITLE
New tricks to tricks.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more examples, see the [usage documentation](./docs/usage.md).
 
 Many thanks to the wizard skating community for their valuable feedback and support. Special thanks to:
 
-- Billy Arlew: for being a reliable source of inspiration and domain knowledge to the wizard tricks dictionary.
+- Billy Arlew: for being a reliable source of inspiration and as a [domain knowledge expert on the wizard skating tricks dictionary](https://eccentricinline.com/).
 - Eelco Soesman: for being a supportive Slightly Rockerd crew and early tester.
 - Bas Bavinck: for being the beacon of wizardry with his book and supporting this project.
 

--- a/src/wzrdbrain/tricks.json
+++ b/src/wzrdbrain/tricks.json
@@ -5,7 +5,8 @@
     "predator", "predator one", "parallel", "tree", "gazelle", "gazelle s",
     "lion", "lion s", "toe press", "heel press", "toe roll", "heel roll",
     "360", "180", "540", "parallel slide", "soul slide", "acid slide",
-    "mizu slide", "star slide", "fast slide", "back slide", "tsunami"
+    "mizu slide", "star slide", "fast slide", "back slide", "stunami",
+    "ufo swivel", "toe pivot", "heel pivot"
   ],
   "RULES": {
     "ONLY_FIRST": ["predator", "predator one", "parallel"],
@@ -15,6 +16,6 @@
       "fast slide", "back slide"
     ],
     "EXCLUDE_STANCE_BASE": ["predator", "predator one"],
-    "ROTATING_MOVES": ["gazelle", "lion", "180", "540"]
+    "ROTATING_MOVES": ["gazelle", "lion", "180", "540", "stunami", "ufo swivel"]
   }
 }

--- a/src/wzrdbrain/wzrdbrain.js
+++ b/src/wzrdbrain/wzrdbrain.js
@@ -10,7 +10,8 @@ const MOVES = [
   "predator", "predator one", "parallel", "tree", "gazelle", "gazelle s",
   "lion", "lion s", "toe press", "heel press", "toe roll", "heel roll",
   "360", "180", "540", "parallel slide", "soul slide", "acid slide",
-  "mizu slide", "star slide", "fast slide", "back slide", "tsunami"
+  "mizu slide", "star slide", "fast slide", "back slide", "stunami",
+  "ufo swivel", "toe pivot", "heel pivot"
 ];
 
 // Rules converted to Set for efficient lookups, mirroring Python's set usage
@@ -21,7 +22,7 @@ const useFakie = new Set([
   "fast slide", "back slide"
 ]);
 const excludeStanceBase = new Set(["predator", "predator one"]);
-const rotatingMoves = new Set(["gazelle", "lion", "180", "540"]);
+const rotatingMoves = new Set(["gazelle", "lion", "180", "540", "stunami", "ufo swivel"]);
 
 // Derived rules, mirroring Python's `exclude_stance` and `SUBSEQUENT_MOVES`
 /**


### PR DESCRIPTION
This pull request updates the wizard skating tricks dictionary with new tricks, corrects a typo, and improves documentation. The most important changes are grouped below.

Trick dictionary updates:

* Added new tricks: `ufo swivel`, `toe pivot`, and `heel pivot` to the `TRICKS` list.
* Corrected the spelling of `tsunami` to `stunami` in the `TRICKS` list and added `stunami` and `ufo swivel` to the `ROTATING_MOVES` category. [[1]](diffhunk://#diff-304d810367bdcf740cdc386f7d08e357ef6b541bff74cf409b8bdb656621fbf3L8-R9) [[2]](diffhunk://#diff-304d810367bdcf740cdc386f7d08e357ef6b541bff74cf409b8bdb656621fbf3L18-R19)

Documentation improvements:

* Updated the README to clarify Billy Arlew's role and added a link to his domain expertise.