### PR TITLE
Fix data sync, version mismatch, ruff config, and add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ Issues = "https://github.com/nazroll/wzrdbrain/issues"
 [tool.ruff]
 line-length = 100
 lint.extend-select = ["Q", "UP"]
-lint.extend-ignore = ["E501"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "wzrdbrain"
 version = "0.2.1"
-description = "A simple library to generate trick combinations for wizard skating."
+description = "A simple library to generate trick combinations and moves for wizard style inline skating."
 readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ classifiers = [
 dev = [
     "pytest",
     "ruff",
-    "black",
+    "black>=26.1.0",
     "mypy",
     "build",
     "google-genai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ classifiers = [
 dev = [
     "pytest",
     "ruff",
-    "black>=26.1.0",
+    "black; python_version < '3.10'",
+    "black>=26.1.0; python_version >= '3.10'",
     "mypy",
     "build",
     "google-genai"

--- a/src/wzrdbrain/__init__.py
+++ b/src/wzrdbrain/__init__.py
@@ -1,10 +1,10 @@
-from .wzrdbrain import generate_combo
-
 """
 wzrdbrain: Basic APIs to generate tricks for wizard skating.
 """
 
+from .wzrdbrain import generate_combo
+
 
 __all__ = ["generate_combo"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.1"

--- a/src/wzrdbrain/__init__.py
+++ b/src/wzrdbrain/__init__.py
@@ -4,7 +4,6 @@ wzrdbrain: Basic APIs to generate tricks for wizard skating.
 
 from .wzrdbrain import generate_combo
 
-
 __all__ = ["generate_combo"]
 
 __version__ = "0.2.1"

--- a/tests/test_wzrdbrain.py
+++ b/tests/test_wzrdbrain.py
@@ -75,3 +75,28 @@ def test_generate_combo_only_first_rule() -> None:
         # Check all tricks after the first one
         for trick_dict in combo[1:]:
             assert trick_dict["move"] not in only_first
+
+
+def test_rotating_move_flips_exit_direction() -> None:
+    # gazelle entering front should exit back, and vice versa
+    trick_front = Trick(direction="front", move="gazelle")
+    assert trick_front.exit_from_trick == "back"
+
+    trick_back = Trick(direction="back", move="gazelle")
+    assert trick_back.exit_from_trick == "front"
+
+
+def test_generate_combo_edge_cases() -> None:
+    assert generate_combo(0) == []
+    assert len(generate_combo(1)) == 1
+
+
+def test_stance_excluded_for_certain_moves() -> None:
+    # Predator moves should never have a stance
+    for _ in range(10):
+        trick = Trick(move="predator")
+        assert trick.stance is None
+
+    # USE_FAKIE moves should also have no stance
+    trick = Trick(move="360")
+    assert trick.stance is None

--- a/utils/wzrdbrain.base.js
+++ b/utils/wzrdbrain.base.js
@@ -11,7 +11,8 @@ const DATA_JSON = {
     "predator", "predator one", "parallel", "tree", "gazelle", "gazelle s",
     "lion", "lion s", "toe press", "heel press", "toe roll", "heel roll",
     "360", "180", "540", "parallel slide", "soul slide", "acid slide",
-    "mizu slide", "star slide", "fast slide", "back slide"
+    "mizu slide", "star slide", "fast slide", "back slide", "stunami",
+    "ufo swivel", "toe pivot", "heel pivot"
   ],
   "RULES": {
     "ONLY_FIRST": ["predator", "predator one", "parallel"],
@@ -21,7 +22,7 @@ const DATA_JSON = {
       "fast slide", "back slide"
     ],
     "EXCLUDE_STANCE_BASE": ["predator", "predator one"],
-    "ROTATING_MOVES": ["gazelle", "lion", "180", "540"]
+    "ROTATING_MOVES": ["gazelle", "lion", "180", "540", "stunami", "ufo swivel"]
   }
 };
 


### PR DESCRIPTION
## Summary

- Sync `wzrdbrain.base.js` `DATA_JSON` with `tricks.json` (add `stunami`, `ufo swivel`, `toe pivot`, `heel pivot` to MOVES; add `stunami` and `ufo swivel` to ROTATING_MOVES)
- Fix `__version__` in `__init__.py` from `0.1.0` to `0.2.1` to match `pyproject.toml`, and move module docstring to line 1
- Remove contradictory `lint.extend-ignore = ["E501"]` from `pyproject.toml` so ruff enforces line length consistently with black
- Add tests for rotating move direction flip, combo edge cases (0 and 1), and stance exclusion for predator/USE_FAKIE moves
- Fix CI failure by conditionally requiring `black>=26.1.0` for Python 3.10+ using PEP 508 environment markers.

## Test plan

- [x] `ruff check .` passes
- [x] `black --check .` passes
- [x] `mypy .` passes
- [x] `pytest -v` passes (10 tests, including 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [Gemini CLI](https://geminicli.com/)
