### PR TITLE
feat: implement realism filters for combo generation

### DIFF
--- a/src/wzrdbrain/wzrdbrain.js
+++ b/src/wzrdbrain/wzrdbrain.js
@@ -593,41 +593,37 @@ const MOVE_LIBRARY = {
 const MOVES = Object.fromEntries(MOVE_LIBRARY.moves.map(m => [m.id, m]));
 
 /**
- * Represents a single trick, resolving its entry and exit states based on
- * the move definition from the library.
+ * Represents a single trick with its resolved entry and exit states.
  */
 export class Trick {
   /**
-   * @param {string} moveId The unique identifier for the move.
+   * @param {string} moveId - The unique identifier for the move.
    */
   constructor(moveId) {
     const move = MOVES[moveId];
-    if (!move) {
-      throw new Error(`Move with ID "${moveId}" not found in library.`);
-    }
+    if (!move) throw new Error(`Invalid move ID: ${moveId}`);
 
     this.moveId = moveId;
-
+    
     // Entry states are absolute
     this.direction = move.entry.direction;
     this.edge = move.entry.edge;
     this.stance = move.entry.stance;
     this.point = move.entry.point;
 
-    // Resolve Exit States based on entry states
+    // Resolve Exit States
     this.exitDirection = this._resolveRelative(move.exit.direction, this.direction);
     this.exitEdge = this._resolveRelative(move.exit.edge, this.edge);
     this.exitStance = this._resolveRelative(move.exit.stance, this.stance);
-    this.exitPoint = move.exit.point; // Exit point is always absolute
+    this.exitPoint = move.exit.point; // Point is always absolute
   }
 
   /**
-   * Resolves a relative state value (e.g., "same" or "opposite") into an
-   * absolute state (e.g., "front", "back").
-   * @param {string} value The relative value ("same", "opposite", or an absolute value).
-   * @param {string} base The base absolute value to compare against.
-   * @returns {string} The resolved absolute state.
+   * Resolves relative state values like "same" or "opposite".
    * @private
+   * @param {string} value - The relative value (e.g., 'same', 'opposite').
+   * @param {string} base - The base state value (e.g., 'front', 'inside').
+   * @returns {string} The resolved absolute state value.
    */
   _resolveRelative(value, base) {
     if (value === "same") {
@@ -635,12 +631,12 @@ export class Trick {
     }
     if (value === "opposite") {
       const opposites = {
-        "front": "back",
-        "back": "front",
-        "inside": "outside",
-        "outside": "inside",
-        "open": "closed",
-        "closed": "open",
+        front: "back",
+        back: "front",
+        inside: "outside",
+        outside: "inside",
+        open: "closed",
+        closed: "open",
       };
       return opposites[base] || base;
     }
@@ -648,48 +644,114 @@ export class Trick {
   }
 
   /**
-   * Returns the human-readable name of the trick's move.
-   * @returns {string} The name of the move.
+   * @returns {string} The human-readable name of the trick's move.
    */
   toString() {
     return MOVES[this.moveId].name;
   }
 
   /**
-   * Returns a plain object representation of the trick, including its
-   * resolved entry and exit states.
-   * @returns {object} A plain object representation.
+   * @returns {object} A plain object representation of the trick.
    */
   toObject() {
     const move = MOVES[this.moveId];
     return {
-      "id": this.moveId,
-      "name": move.name,
-      "category": move.category,
-      "stage": move.stage,
-      "entry": {
-        "direction": this.direction,
-        "edge": this.edge,
-        "stance": this.stance,
-        "point": this.point,
+      id: this.moveId,
+      name: move.name,
+      category: move.category,
+      stage: move.stage,
+      entry: {
+        direction: this.direction,
+        edge: this.edge,
+        stance: this.stance,
+        point: this.point,
       },
-      "exit": {
-        "direction": this.exitDirection,
-        "edge": this.exitEdge,
-        "stance": this.exitStance,
-        "point": this.exitPoint,
+      exit: {
+        direction: this.exitDirection,
+        edge: this.exitEdge,
+        stance: this.exitStance,
+        point: this.exitPoint,
       },
     };
   }
 }
 
 /**
- * Generates a combination of tricks based on physical state transitions.
- * It attempts to find a subsequent trick whose entry state strictly matches
- * the previous trick's exit state (direction and weight point), falling back
- * to a relaxed match (direction only) if needed.
- * @param {number|null} [numTricks=null] - Number of tricks to generate. If null, a random number between 2 and 5 is chosen.
- * @param {number} [maxStage=5] - The maximum skill stage of moves to include in the combo.
+ * Applies realism constraints to candidate moves.
+ * If hardCategory is true and category diversity cannot be satisfied,
+ * returns an empty array to signal the caller to try a wider candidate pool.
+ * If hardCategory is false, it applies other constraints even if the category repeats.
+ * @private
+ * @param {object[]} candidates - Array of move objects to filter.
+ * @param {Trick[]} combo - The sequence of tricks generated so far.
+ * @param {boolean} [hardCategory=true] - Whether to enforce strict category diversity.
+ * @returns {object[]} The filtered list of candidate moves.
+ */
+function _applyRealismFilters(candidates, combo, hardCategory = true) {
+  if (!candidates.length || !combo.length) {
+    return candidates;
+  }
+
+  const lastMove = MOVES[combo[combo.length - 1].moveId];
+  let filtered = candidates;
+
+  // Constraint 1: Max 2 consecutive same category (general)
+  if (combo.length >= 2) {
+    const prevMove = MOVES[combo[combo.length - 2].moveId];
+    if (prevMove.category === lastMove.category && lastMove.category !== "slide") {
+      const noCat = filtered.filter(m => m.category !== lastMove.category);
+      if (noCat.length === 0 && hardCategory) {
+        return [];
+      }
+      if (noCat.length > 0) {
+        filtered = noCat;
+      }
+    }
+  }
+
+  // Constraint 1b: Specific slide probability
+  if (lastMove.category === "slide") {
+    // Hard cap at 2 consecutive slides
+    if (combo.length >= 2 && MOVES[combo[combo.length - 2].moveId].category === "slide") {
+      const noSlide = filtered.filter(m => m.category !== "slide");
+      // This is an absolute hard cap, never soft-fallback to more slides
+      return noSlide.length > 0 ? noSlide : [];
+    } else {
+      // 10% chance to allow a second consecutive slide
+      if (Math.random() > 0.10) {
+        const noSlide = filtered.filter(m => m.category !== "slide");
+        if (noSlide.length === 0 && hardCategory) {
+          return [];
+        }
+        if (noSlide.length > 0) {
+          filtered = noSlide;
+        }
+      }
+    }
+  }
+
+  // Constraint 2: No consecutive same move
+  const noDup = filtered.filter(m => m.id !== lastMove.id);
+  if (noDup.length > 0) {
+    filtered = noDup;
+  }
+
+  // Constraint 3: No consecutive high-rotation (degrees >= 360)
+  if (lastMove.mechanics.degrees >= 360) {
+    const noSpin = filtered.filter(m => m.mechanics.degrees < 360);
+    if (noSpin.length > 0) {
+      filtered = noSpin;
+    }
+  }
+
+  return filtered;
+}
+
+/**
+ * Generates a combination of tricks based on physical state transitions and realism filters.
+ *
+ * @param {number|null} [numTricks=null] - The number of tricks to generate. If null, a random number between 2 and 5 is chosen.
+ * @param {number} [maxStage=5] - The maximum skill stage of moves to include.
  * @returns {object[]} An array of trick objects representing the generated combo.
  */
 export function generateCombo(numTricks = null, maxStage = 5) {
@@ -711,25 +773,39 @@ export function generateCombo(numTricks = null, maxStage = 5) {
   let currentTrick = new Trick(firstMove.id);
   combo.push(currentTrick);
 
-  // 2. Iteratively find compatible subsequent moves
+  // 2. Iteratively find compatible moves using two-tier matching
   for (let i = 0; i < numTricks - 1; i++) {
-    const eligibleMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
+    const eligible = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
 
-    // Tier 1 — Strict match: direction AND weight point must both match
-    const strictCandidates = eligibleMoves.filter(m =>
+    // Tier 1 — strict: direction + point must both match the current exit state
+    const strict = eligible.filter(m =>
       m.entry.direction === currentTrick.exitDirection &&
       m.entry.point === currentTrick.exitPoint
     );
 
-    // Tier 2 — Relaxed match: only direction must match
-    const relaxedCandidates = eligibleMoves.filter(m =>
+    // Tier 2 — relaxed: direction only (implicit edge/point shift between tricks)
+    const relaxed = eligible.filter(m =>
       m.entry.direction === currentTrick.exitDirection
     );
 
-    const candidates = strictCandidates.length > 0 ? strictCandidates : relaxedCandidates;
+    // Apply realism constraints with a tiered fallback system
+    const strictFiltered = strict.length > 0 ? _applyRealismFilters(strict, combo, true) : [];
+    const relaxedFiltered = _applyRealismFilters(relaxed, combo, true);
+
+    let candidates;
+    if (strictFiltered.length > 0) {
+      candidates = strictFiltered;
+    } else if (relaxedFiltered.length > 0) {
+      candidates = relaxedFiltered;
+    } else {
+      // Soft fallback: re-run filter on relaxed pool without hard category enforcement
+      candidates = _applyRealismFilters(relaxed, combo, false);
+    }
 
     if (candidates.length === 0) {
-      break; // Stop if no compatible move can be found
+      // Absolute worst-case fallback, should rarely happen
+      candidates = relaxed;
+      if (candidates.length === 0) break; // No possible moves left
     }
 
     const nextMove = candidates[Math.floor(Math.random() * candidates.length)];

--- a/src/wzrdbrain/wzrdbrain.py
+++ b/src/wzrdbrain/wzrdbrain.py
@@ -131,6 +131,42 @@ class Trick:
         }
 
 
+def _apply_realism_filters(candidates: list[Move], combo: list[Trick]) -> list[Move]:
+    """
+    Applies realism constraints to candidate moves.
+    Returns empty list if category diversity cannot be satisfied,
+    signalling the caller to try a wider candidate pool.
+    """
+    if not combo:
+        return candidates
+
+    last_move = MOVES[combo[-1].move_id]
+    filtered = candidates
+
+    # Constraint 1 (highest priority): Max 2 consecutive same category
+    # Returns empty if unsatisfiable so the caller widens the pool.
+    if len(combo) >= 2:
+        prev_category = MOVES[combo[-2].move_id].category
+        if prev_category == last_move.category:
+            no_cat = [m for m in filtered if m.category != last_move.category]
+            if not no_cat:
+                return []
+            filtered = no_cat
+
+    # Constraint 2: No consecutive same move
+    no_dup = [m for m in filtered if m.id != last_move.id]
+    if no_dup:
+        filtered = no_dup
+
+    # Constraint 3: No consecutive high-rotation (degrees >= 360)
+    if last_move.mechanics.degrees >= 360:
+        no_spin = [m for m in filtered if m.mechanics.degrees < 360]
+        if no_spin:
+            filtered = no_spin
+
+    return filtered
+
+
 def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> list[dict[str, Any]]:
     """
     Generates a combination of tricks based on physical state transitions.
@@ -164,7 +200,16 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
         # Tier 2 — relaxed: direction only (implicit edge/point shift between tricks)
         relaxed = [m for m in eligible if m.entry.direction == current_trick.exit_direction]
 
-        candidates = strict if strict else relaxed
+        # Apply realism constraints to strict pool first, widen to relaxed if needed
+        strict_filtered = _apply_realism_filters(strict, combo) if strict else []
+        relaxed_filtered = _apply_realism_filters(relaxed, combo)
+
+        if strict_filtered:
+            candidates = strict_filtered
+        elif relaxed_filtered:
+            candidates = relaxed_filtered
+        else:
+            candidates = relaxed
 
         next_move = random.choice(candidates)
         current_trick = Trick(next_move.id)

--- a/src/wzrdbrain/wzrdbrain.py
+++ b/src/wzrdbrain/wzrdbrain.py
@@ -131,27 +131,50 @@ class Trick:
         }
 
 
-def _apply_realism_filters(candidates: list[Move], combo: list[Trick]) -> list[Move]:
+def _apply_realism_filters(candidates: list[Move], combo: list[Trick], hard_category: bool = True) -> list[Move]:
     """
     Applies realism constraints to candidate moves.
-    Returns empty list if category diversity cannot be satisfied,
-    signalling the caller to try a wider candidate pool.
+    If hard_category is True and category diversity cannot be satisfied,
+    returns empty list signalling the caller to try a wider candidate pool.
+    If hard_category is False, applies other constraints even if category repeats.
     """
-    if not combo:
+    if not candidates or not combo:
         return candidates
 
     last_move = MOVES[combo[-1].move_id]
     filtered = candidates
 
-    # Constraint 1 (highest priority): Max 2 consecutive same category
-    # Returns empty if unsatisfiable so the caller widens the pool.
+    # Constraint 1: Max 2 consecutive same category (general)
     if len(combo) >= 2:
         prev_category = MOVES[combo[-2].move_id].category
-        if prev_category == last_move.category:
+        if prev_category == last_move.category and last_move.category != "slide":
             no_cat = [m for m in filtered if m.category != last_move.category]
-            if not no_cat:
+            if not no_cat and hard_category:
                 return []
-            filtered = no_cat
+            if no_cat:
+                filtered = no_cat
+
+    # Constraint 1b: Specific slide probability
+    if last_move.category == "slide":
+        # Hard cap at 2 slides (absolute, ignores hard_category flag)
+        if len(combo) >= 2 and MOVES[combo[-2].move_id].category == "slide":
+            no_slide = [m for m in filtered if m.category != "slide"]
+            if not no_slide: # Absolute hard cap, never soft-fallback back into slides
+                return []
+            filtered = no_slide
+        else:
+            # 10% chance to allow consecutive slides if we haven't hit the cap
+            # If random check fails, we try to force a non-slide
+            if random.random() > 0.10:
+                no_slide = [m for m in filtered if m.category != "slide"]
+                if not no_slide and hard_category:
+                    return []
+                # Only apply the no_slide filter if it leaves us with options, 
+                # OR if we are doing a hard constraint (which we just checked).
+                # Wait, if we are in soft-fallback (hard_category=False) and there are no non-slides,
+                # we SHOULD NOT set filtered = no_slide (which is empty). We keep the slides!
+                if no_slide:
+                    filtered = no_slide
 
     # Constraint 2: No consecutive same move
     no_dup = [m for m in filtered if m.id != last_move.id]
@@ -201,14 +224,18 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
         relaxed = [m for m in eligible if m.entry.direction == current_trick.exit_direction]
 
         # Apply realism constraints to strict pool first, widen to relaxed if needed
-        strict_filtered = _apply_realism_filters(strict, combo) if strict else []
-        relaxed_filtered = _apply_realism_filters(relaxed, combo)
+        strict_filtered = _apply_realism_filters(strict, combo, hard_category=True) if strict else []
+        relaxed_filtered = _apply_realism_filters(relaxed, combo, hard_category=True)
 
         if strict_filtered:
             candidates = strict_filtered
         elif relaxed_filtered:
             candidates = relaxed_filtered
         else:
+            candidates = _apply_realism_filters(relaxed, combo, hard_category=False)
+            
+        if not candidates:
+            # Absolute worst-case fallback, should rarely be hit given the library size
             candidates = relaxed
 
         next_move = random.choice(candidates)

--- a/src/wzrdbrain/wzrdbrain.py
+++ b/src/wzrdbrain/wzrdbrain.py
@@ -131,7 +131,9 @@ class Trick:
         }
 
 
-def _apply_realism_filters(candidates: list[Move], combo: list[Trick], hard_category: bool = True) -> list[Move]:
+def _apply_realism_filters(
+    candidates: list[Move], combo: list[Trick], hard_category: bool = True
+) -> list[Move]:
     """
     Applies realism constraints to candidate moves.
     If hard_category is True and category diversity cannot be satisfied,
@@ -159,7 +161,7 @@ def _apply_realism_filters(candidates: list[Move], combo: list[Trick], hard_cate
         # Hard cap at 2 slides (absolute, ignores hard_category flag)
         if len(combo) >= 2 and MOVES[combo[-2].move_id].category == "slide":
             no_slide = [m for m in filtered if m.category != "slide"]
-            if not no_slide: # Absolute hard cap, never soft-fallback back into slides
+            if not no_slide:  # Absolute hard cap, never soft-fallback back into slides
                 return []
             filtered = no_slide
         else:
@@ -169,10 +171,6 @@ def _apply_realism_filters(candidates: list[Move], combo: list[Trick], hard_cate
                 no_slide = [m for m in filtered if m.category != "slide"]
                 if not no_slide and hard_category:
                     return []
-                # Only apply the no_slide filter if it leaves us with options, 
-                # OR if we are doing a hard constraint (which we just checked).
-                # Wait, if we are in soft-fallback (hard_category=False) and there are no non-slides,
-                # we SHOULD NOT set filtered = no_slide (which is empty). We keep the slides!
                 if no_slide:
                     filtered = no_slide
 
@@ -224,7 +222,9 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
         relaxed = [m for m in eligible if m.entry.direction == current_trick.exit_direction]
 
         # Apply realism constraints to strict pool first, widen to relaxed if needed
-        strict_filtered = _apply_realism_filters(strict, combo, hard_category=True) if strict else []
+        strict_filtered = (
+            _apply_realism_filters(strict, combo, hard_category=True) if strict else []
+        )
         relaxed_filtered = _apply_realism_filters(relaxed, combo, hard_category=True)
 
         if strict_filtered:
@@ -233,7 +233,7 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
             candidates = relaxed_filtered
         else:
             candidates = _apply_realism_filters(relaxed, combo, hard_category=False)
-            
+
         if not candidates:
             # Absolute worst-case fallback, should rarely be hit given the library size
             candidates = relaxed

--- a/tests/test_wzrdbrain.py
+++ b/tests/test_wzrdbrain.py
@@ -217,9 +217,9 @@ def test_no_consecutive_duplicate_tricks() -> None:
     for _ in range(100):
         combo = generate_combo(5)
         for i in range(len(combo) - 1):
-            assert combo[i]["id"] != combo[i + 1]["id"], (
-                f"Consecutive duplicate: {combo[i]['name']} at positions {i} and {i + 1}"
-            )
+            assert (
+                combo[i]["id"] != combo[i + 1]["id"]
+            ), f"Consecutive duplicate: {combo[i]['name']} at positions {i} and {i + 1}"
 
 
 def test_max_consecutive_same_category() -> None:
@@ -269,6 +269,7 @@ def test_move_count_covers_old_library() -> None:
     # New library enumerates all variants explicitly, so it should be larger
     assert len(_LIBRARY.moves) >= 26, f"Expected at least 26 moves, got {len(_LIBRARY.moves)}"
 
+
 def test_realism_filters_does_not_bypass_duplicates_on_category_failure() -> None:
     """
     If the engine is forced to repeat a category (because no other valid transitions exist),
@@ -276,38 +277,38 @@ def test_realism_filters_does_not_bypass_duplicates_on_category_failure() -> Non
     """
     # Use 'turn' category moves so we trigger Constraint 1, but not the hard slide cap
     combo = [Trick("parallel_turn_o"), Trick("tree_turn_c")]
-    
+
     candidates = [
-        MOVES["tree_turn_c"], # Duplicate of last move
-        MOVES["parallel_turn_c"] # Valid new move in the same category
+        MOVES["tree_turn_c"],  # Duplicate of last move
+        MOVES["parallel_turn_c"],  # Valid new move in the same category
     ]
-    
+
     # We pass hard_category=False to simulate the fallback behavior in generate_combo
     filtered = _apply_realism_filters(candidates, combo, hard_category=False)
-    
+
     assert MOVES["tree_turn_c"] not in filtered, "Filter bypassed Constraint 2 (Duplicates)!"
-    assert MOVES["parallel_turn_c"] in filtered, "Filter dropped all candidates instead of falling back to soft constraints!"
+    assert (
+        MOVES["parallel_turn_c"] in filtered
+    ), "Filter dropped all candidates instead of falling back to soft constraints!"
+
 
 def test_slide_probability_constraint() -> None:
     """Test that a third consecutive slide is strictly forbidden, even with soft fallback."""
     combo = [Trick("parallel_slide_f"), Trick("back_slide_f")]
-    candidates = [MOVES["mizu_slide_f"]] # Valid state transition, but it's a 3rd slide
-    
+    candidates = [MOVES["mizu_slide_f"]]  # Valid state transition, but it's a 3rd slide
+
     # Even on soft fallback, it should return [] if the only option is a 3rd slide.
     filtered = _apply_realism_filters(candidates, combo, hard_category=False)
     assert not filtered, "Filter allowed a 3rd consecutive slide!"
 
+
 def test_realism_filters_soft_fallback_keeps_options() -> None:
     """Test that if category constraint fails, we still get non-duplicate options back."""
     combo = [Trick("predator_f_o")]
-    
+
     # Suppose the only valid next moves are base moves again
-    candidates = [
-        MOVES["predator_f_o"], # Duplicate
-        MOVES["predator_one_f"] # New
-    ]
-    
+    candidates = [MOVES["predator_f_o"], MOVES["predator_one_f"]]  # Duplicate  # New
+
     filtered = _apply_realism_filters(candidates, combo, hard_category=False)
     assert len(filtered) == 1
     assert filtered[0].id == "predator_one_f"
-

--- a/tests/test_wzrdbrain.py
+++ b/tests/test_wzrdbrain.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wzrdbrain.wzrdbrain import Trick, generate_combo, MOVES, _LIBRARY
+from wzrdbrain.wzrdbrain import Trick, generate_combo, MOVES, _LIBRARY, _apply_realism_filters
 
 # --- Existing tests (updated for corrected data) ---
 
@@ -268,3 +268,46 @@ def test_move_count_covers_old_library() -> None:
     # Old library had 26 moves (without direction/stance variants)
     # New library enumerates all variants explicitly, so it should be larger
     assert len(_LIBRARY.moves) >= 26, f"Expected at least 26 moves, got {len(_LIBRARY.moves)}"
+
+def test_realism_filters_does_not_bypass_duplicates_on_category_failure() -> None:
+    """
+    If the engine is forced to repeat a category (because no other valid transitions exist),
+    it must STILL apply the duplicate and spin filters via a soft fallback.
+    """
+    # Use 'turn' category moves so we trigger Constraint 1, but not the hard slide cap
+    combo = [Trick("parallel_turn_o"), Trick("tree_turn_c")]
+    
+    candidates = [
+        MOVES["tree_turn_c"], # Duplicate of last move
+        MOVES["parallel_turn_c"] # Valid new move in the same category
+    ]
+    
+    # We pass hard_category=False to simulate the fallback behavior in generate_combo
+    filtered = _apply_realism_filters(candidates, combo, hard_category=False)
+    
+    assert MOVES["tree_turn_c"] not in filtered, "Filter bypassed Constraint 2 (Duplicates)!"
+    assert MOVES["parallel_turn_c"] in filtered, "Filter dropped all candidates instead of falling back to soft constraints!"
+
+def test_slide_probability_constraint() -> None:
+    """Test that a third consecutive slide is strictly forbidden, even with soft fallback."""
+    combo = [Trick("parallel_slide_f"), Trick("back_slide_f")]
+    candidates = [MOVES["mizu_slide_f"]] # Valid state transition, but it's a 3rd slide
+    
+    # Even on soft fallback, it should return [] if the only option is a 3rd slide.
+    filtered = _apply_realism_filters(candidates, combo, hard_category=False)
+    assert not filtered, "Filter allowed a 3rd consecutive slide!"
+
+def test_realism_filters_soft_fallback_keeps_options() -> None:
+    """Test that if category constraint fails, we still get non-duplicate options back."""
+    combo = [Trick("predator_f_o")]
+    
+    # Suppose the only valid next moves are base moves again
+    candidates = [
+        MOVES["predator_f_o"], # Duplicate
+        MOVES["predator_one_f"] # New
+    ]
+    
+    filtered = _apply_realism_filters(candidates, combo, hard_category=False)
+    assert len(filtered) == 1
+    assert filtered[0].id == "predator_one_f"
+

--- a/tests/test_wzrdbrain.py
+++ b/tests/test_wzrdbrain.py
@@ -212,6 +212,41 @@ def test_swivel_category_exists() -> None:
     assert MOVES["ufo_swivel_b"].category == "swivel"
 
 
+def test_no_consecutive_duplicate_tricks() -> None:
+    """No adjacent tricks in a combo should be the same move."""
+    for _ in range(100):
+        combo = generate_combo(5)
+        for i in range(len(combo) - 1):
+            assert combo[i]["id"] != combo[i + 1]["id"], (
+                f"Consecutive duplicate: {combo[i]['name']} at positions {i} and {i + 1}"
+            )
+
+
+def test_max_consecutive_same_category() -> None:
+    """No more than 2 consecutive tricks from the same category."""
+    for _ in range(100):
+        combo = generate_combo(5)
+        for i in range(len(combo) - 2):
+            cats = [combo[i]["category"], combo[i + 1]["category"], combo[i + 2]["category"]]
+            assert not (cats[0] == cats[1] == cats[2]), (
+                f"3 consecutive same category '{cats[0]}': "
+                f"{combo[i]['name']}, {combo[i+1]['name']}, {combo[i+2]['name']}"
+            )
+
+
+def test_no_consecutive_high_rotation() -> None:
+    """No adjacent tricks should both have degrees >= 360."""
+    for _ in range(100):
+        combo = generate_combo(5)
+        for i in range(len(combo) - 1):
+            curr_deg = MOVES[combo[i]["id"]].mechanics.degrees
+            next_deg = MOVES[combo[i + 1]["id"]].mechanics.degrees
+            assert not (curr_deg >= 360 and next_deg >= 360), (
+                f"Consecutive high-rotation: {combo[i]['name']} ({curr_deg}°) → "
+                f"{combo[i+1]['name']} ({next_deg}°)"
+            )
+
+
 def test_gazelle_entry_edge_is_outside() -> None:
     """Gazelles (two-footed) should enter on outside edge (leading-foot convention)."""
     for move_id in ["gazelle_f_o", "gazelle_b_o", "gazelle_s_f_o", "gazelle_s_b_o"]:

--- a/utils/wzrdbrain.base.js
+++ b/utils/wzrdbrain.base.js
@@ -97,27 +97,44 @@ export class Trick {
 
 /**
  * Applies realism constraints to candidate moves.
- * Returns empty array if category diversity cannot be satisfied,
- * signalling the caller to try a wider candidate pool.
+ * If hardCategory is true and category diversity cannot be satisfied,
+ * returns an empty array to signal the caller to try a wider candidate pool.
+ * If hardCategory is false, applies other constraints even if the category repeats.
  * @private
  * @param {object[]} candidates - Array of move objects.
  * @param {Trick[]} combo - Tricks selected so far.
+ * @param {boolean} [hardCategory=true] - Whether to enforce strict category diversity.
  * @returns {object[]} Filtered candidates.
  */
-function _applyRealismFilters(candidates, combo) {
-  if (combo.length === 0) return candidates;
+function _applyRealismFilters(candidates, combo, hardCategory = true) {
+  if (candidates.length === 0 || combo.length === 0) return candidates;
 
   const lastMove = MOVES[combo[combo.length - 1].moveId];
   let filtered = candidates;
 
-  // Constraint 1 (highest priority): Max 2 consecutive same category
-  // Returns empty if unsatisfiable so the caller widens the pool.
+  // Constraint 1: Max 2 consecutive same category (general, excludes slides)
   if (combo.length >= 2) {
     const prevMove = MOVES[combo[combo.length - 2].moveId];
-    if (prevMove.category === lastMove.category) {
+    if (prevMove.category === lastMove.category && lastMove.category !== "slide") {
       const noCat = filtered.filter(m => m.category !== lastMove.category);
-      if (noCat.length === 0) return [];
-      filtered = noCat;
+      if (noCat.length === 0 && hardCategory) return [];
+      if (noCat.length > 0) filtered = noCat;
+    }
+  }
+
+  // Constraint 1b: Specific slide probability
+  if (lastMove.category === "slide") {
+    // Hard cap at 2 consecutive slides (absolute, ignores hardCategory flag)
+    if (combo.length >= 2 && MOVES[combo[combo.length - 2].moveId].category === "slide") {
+      const noSlide = filtered.filter(m => m.category !== "slide");
+      return noSlide.length > 0 ? noSlide : [];
+    } else {
+      // 10% chance to allow a second consecutive slide
+      if (Math.random() > 0.10) {
+        const noSlide = filtered.filter(m => m.category !== "slide");
+        if (noSlide.length === 0 && hardCategory) return [];
+        if (noSlide.length > 0) filtered = noSlide;
+      }
     }
   }
 
@@ -173,9 +190,9 @@ export function generateCombo(numTricks = null, maxStage = 5) {
 
     if (relaxedCandidates.length === 0) break; // Should theoretically not happen with a complete library
 
-    // Apply realism constraints to strict pool first, widen to relaxed if needed
-    const strictFiltered = strictCandidates.length > 0 ? _applyRealismFilters(strictCandidates, combo) : [];
-    const relaxedFiltered = _applyRealismFilters(relaxedCandidates, combo);
+    // Apply realism constraints with tiered fallback
+    const strictFiltered = strictCandidates.length > 0 ? _applyRealismFilters(strictCandidates, combo, true) : [];
+    const relaxedFiltered = _applyRealismFilters(relaxedCandidates, combo, true);
 
     let candidates;
     if (strictFiltered.length > 0) {
@@ -183,7 +200,14 @@ export function generateCombo(numTricks = null, maxStage = 5) {
     } else if (relaxedFiltered.length > 0) {
       candidates = relaxedFiltered;
     } else {
+      // Soft fallback: relax category enforcement but keep dedup and spin limits
+      candidates = _applyRealismFilters(relaxedCandidates, combo, false);
+    }
+
+    if (candidates.length === 0) {
+      // Absolute worst-case fallback
       candidates = relaxedCandidates;
+      if (candidates.length === 0) break;
     }
 
     const nextMove = candidates[Math.floor(Math.random() * candidates.length)];

--- a/utils/wzrdbrain.base.js
+++ b/utils/wzrdbrain.base.js
@@ -96,6 +96,45 @@ export class Trick {
 }
 
 /**
+ * Applies realism constraints to candidate moves.
+ * Returns empty array if category diversity cannot be satisfied,
+ * signalling the caller to try a wider candidate pool.
+ * @private
+ * @param {object[]} candidates - Array of move objects.
+ * @param {Trick[]} combo - Tricks selected so far.
+ * @returns {object[]} Filtered candidates.
+ */
+function _applyRealismFilters(candidates, combo) {
+  if (combo.length === 0) return candidates;
+
+  const lastMove = MOVES[combo[combo.length - 1].moveId];
+  let filtered = candidates;
+
+  // Constraint 1 (highest priority): Max 2 consecutive same category
+  // Returns empty if unsatisfiable so the caller widens the pool.
+  if (combo.length >= 2) {
+    const prevMove = MOVES[combo[combo.length - 2].moveId];
+    if (prevMove.category === lastMove.category) {
+      const noCat = filtered.filter(m => m.category !== lastMove.category);
+      if (noCat.length === 0) return [];
+      filtered = noCat;
+    }
+  }
+
+  // Constraint 2: No consecutive same move
+  const noDup = filtered.filter(m => m.id !== lastMove.id);
+  if (noDup.length > 0) filtered = noDup;
+
+  // Constraint 3: No consecutive high-rotation (degrees >= 360)
+  if (lastMove.mechanics.degrees >= 360) {
+    const noSpin = filtered.filter(m => m.mechanics.degrees < 360);
+    if (noSpin.length > 0) filtered = noSpin;
+  }
+
+  return filtered;
+}
+
+/**
  * Generates a combination of tricks based on physical state transitions.
  *
  * @param {number|null} [numTricks=null] - Number of tricks to generate.
@@ -111,7 +150,7 @@ export function generateCombo(numTricks = null, maxStage = 5) {
 
   const combo = [];
   const validMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
-  
+
   if (validMoves.length === 0) return [];
 
   // 1. Select the first trick
@@ -122,7 +161,7 @@ export function generateCombo(numTricks = null, maxStage = 5) {
   // 2. Iteratively find compatible moves using two-tier matching
   for (let i = 0; i < numTricks - 1; i++) {
     // Tier 1 — strict: direction + point must both match the current exit state
-    const strictCandidates = validMoves.filter(m => 
+    const strictCandidates = validMoves.filter(m =>
       m.entry.direction === currentTrick.exitDirection &&
       m.entry.point === currentTrick.exitPoint
     );
@@ -132,9 +171,20 @@ export function generateCombo(numTricks = null, maxStage = 5) {
       m.entry.direction === currentTrick.exitDirection
     );
 
-    const candidates = strictCandidates.length > 0 ? strictCandidates : relaxedCandidates;
+    if (relaxedCandidates.length === 0) break; // Should theoretically not happen with a complete library
 
-    if (candidates.length === 0) break; // Should theoretically not happen with a complete library
+    // Apply realism constraints to strict pool first, widen to relaxed if needed
+    const strictFiltered = strictCandidates.length > 0 ? _applyRealismFilters(strictCandidates, combo) : [];
+    const relaxedFiltered = _applyRealismFilters(relaxedCandidates, combo);
+
+    let candidates;
+    if (strictFiltered.length > 0) {
+      candidates = strictFiltered;
+    } else if (relaxedFiltered.length > 0) {
+      candidates = relaxedFiltered;
+    } else {
+      candidates = relaxedCandidates;
+    }
 
     const nextMove = candidates[Math.floor(Math.random() * candidates.length)];
     currentTrick = new Trick(nextMove.id);


### PR DESCRIPTION
Fixes unnatural patterns observed in generated combinations.

**Improvements:**
- **No Consecutive Duplicates:** Ensures the exact same trick isn't generated back-to-back.
- **Spin Limiter:** Prevents back-to-back high-rotation moves (360° or more).
- **Category Diversity:** Limits consecutive moves of the same category to a maximum of 2.
- **Slide Probability Constraint:** Significantly reduces the chance (to 10%) of consecutive slide moves, with an absolute maximum of 2 slides.
- **Soft Fallback Mechanism:** Ensures that if the strict category constraints cannot be met by available state transitions, the generator falls back to enforcing duplicates and spin limits rather than dropping all constraints entirely.

Unit tests have been added to verify the soft fallback and slide limiters.