### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+* @nazroll


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with @nazroll as default owner for all files
- Ensures automatic review requests on all PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)