### PR TITLE
fix: correct broken links and outdated references in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ If you'd like to fix a bug or add a new feature to the Python or JavaScript code
 ### Development setup
 
 1.  **If you haven't already, fork the repository on GitHub.**
-    * Go to https://github.com/wzrdbrain/wzrdbrain and click "Fork" in the top right.
+    * Go to https://github.com/nazroll/wzrdbrain and click "Fork" in the top right.
 
 2.  **Clone your fork:**
     ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ The JavaScript version is automatically generated from the Python source code us
 
 [![contributors](https://contrib.rocks/image?repo=nazroll/wzrdbrain)](https://github.com/nazroll/wzrdbrain/graphs/contributors)
 
-_**Disclosure:** AI coding assistant tools like Google Gemini CLI, Jules by Google and Github Copilot are used in this project._
+_**Disclosure:** AI coding assistant tools like Claude Code by Anthropic, Google Gemini CLI, Jules by Google and Github Copilot are used in this project._
 
 ## Getting started
 
@@ -38,8 +38,8 @@ For developers, read [usage.md](./usage.md) to learn how to install and use the 
 
 For more detailed information about the data structures used in `wzrdbrain`, please refer to the following documents:
 
-- [The Trick object](./api_reference.md#the-trick-object)
-- [Generating trick combos](./api_reference.md#generating-trick-combos)
+- [The Trick object](./usage.md#the-trick-object)
+- [Generating trick combos](./usage.md#generating-trick-combos)
 
 ## Python-to-JS code translation
 

--- a/docs/translate2js.md
+++ b/docs/translate2js.md
@@ -14,7 +14,7 @@ The script performs the following steps:
 
 1.  It reads the content of three key files:
     *   `src/wzrdbrain/wzrdbrain.py`: The Python source code.
-    *   `src/wzrdbrain/tricks.json`: The JSON data file containing trick definitions and rules.
+    *   `src/wzrdbrain/moves.json`: The JSON data file containing move definitions and rules.
     *   `utils/wzrdbrain.base.js`: A reference JavaScript file that provides the desired structure, style, and conventions for the output.
 2.  It constructs a detailed prompt for the Gemini LLM. This prompt includes the full content of all three source files and a precise set of instructions for the translation, such as:
     *   Embedding the `tricks.json` data directly into the JavaScript file as `const` variables.
@@ -58,7 +58,7 @@ The translation process is automated as part of the project's Github Actions CI 
 
 ### The `translate` job
 
-Whenever changes are pushed to the repository that affect `src/wzrdbrain/wzrdbrain.py` or `src/wzrdbrain/tricks.json`, the CI workflow is triggered. After the test suite passes, the `translate` job automatically performs the following steps:
+Whenever changes are pushed to the repository that affect `src/wzrdbrain/wzrdbrain.py` or `src/wzrdbrain/moves.json`, the CI workflow is triggered. After the test suite passes, the `translate` job automatically performs the following steps:
 
 1.  It executes the `python utils/translate2js.py` script, using a `GEMINI_API_KEY` stored in the repository's secrets.
 2.  It checks if the script generated a new or modified version of `src/wzrdbrain/wzrdbrain.js`.


### PR DESCRIPTION
## Summary
- Fix fork URL in CONTRIBUTING.md (`wzrdbrain/wzrdbrain` → `nazroll/wzrdbrain`)
- Fix `tricks.json` → `moves.json` references in docs/translate2js.md
- Fix broken `api_reference.md` links → `usage.md` in docs/index.md
- Add Claude Code to AI tools disclosure in docs/index.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)