### PR TITLE
chore: add PR merge check policy to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,4 +63,5 @@ python utils/translate2js.py
 ## Branching & Release Policy
 
 - **Never push directly to `main`**. All changes must be made on a working branch and merged via pull request.
+- **Before merging a PR**, wait for all GitHub Actions checks to pass. Do not merge (including with `--admin`) if any check is pending or failing.
 - **New releases may only be created after all GitHub Actions checks have passed** on the merged PR. Do not tag or publish a release if any CI job is failing.


### PR DESCRIPTION
## Summary
- Adds rule requiring all GitHub Actions checks to pass before merging a PR (including with `--admin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)