### PR TITLE
feat: make combo generation edge/stance aware with honest transition labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ python utils/translate2js.py
 **Core library**: `src/wzrdbrain/wzrdbrain.py`
 - Loads and validates `moves.json` via Pydantic models (`Move`, `MoveLibrary`, `State`, `ExitState`, `Mechanics`)
 - `Trick` dataclass: resolves absolute entry/exit states from a move ID; `__post_init__` applies relative state resolution (`same`/`opposite`)
-- `generate_combo(num_of_tricks, max_stage)` — chains tricks using a three-tier cascade: strict (direction + point + edge + stance) preferred, then mid (direction + point), then relaxed (direction only). Each emitted trick records a `transition` annotation (`start`/`linked`/`edge_shift`/`reset`) describing how continuous its link is. Always returns exactly N tricks.
+- `generate_combo(num_of_tricks, max_stage)` — chains tricks using a three-tier cascade: strict (direction + point + edge + stance) preferred, then mid (direction + point), then relaxed (direction only). Each emitted trick records a `transition` annotation (`start`/`linked`/`edge_shift`/`reset`) describing how continuous its link is. Returns exactly N tricks as long as a direction-compatible move exists (always true for the current library); otherwise returns the partial combo rather than dead-ending.
 - `MOVES` dict built at module load for O(1) move lookup by ID
 
 **Data**: `src/wzrdbrain/moves.json` — single source of truth for all 64 move variants. Each move defines entry/exit physical states (direction, edge, stance, point), mechanics, category, and stage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ python utils/translate2js.py
 **Core library**: `src/wzrdbrain/wzrdbrain.py`
 - Loads and validates `moves.json` via Pydantic models (`Move`, `MoveLibrary`, `State`, `ExitState`, `Mechanics`)
 - `Trick` dataclass: resolves absolute entry/exit states from a move ID; `__post_init__` applies relative state resolution (`same`/`opposite`)
-- `generate_combo(num_of_tricks, max_stage)` — chains tricks using two-tier matching: strict (direction + point) preferred, relaxed (direction only) fallback. Always returns exactly N tricks.
+- `generate_combo(num_of_tricks, max_stage)` — chains tricks using a three-tier cascade: strict (direction + point + edge + stance) preferred, then mid (direction + point), then relaxed (direction only). Each emitted trick records a `transition` annotation (`start`/`linked`/`edge_shift`/`reset`) describing how continuous its link is. Always returns exactly N tricks.
 - `MOVES` dict built at module load for O(1) move lookup by ID
 
 **Data**: `src/wzrdbrain/moves.json` — single source of truth for all 64 move variants. Each move defines entry/exit physical states (direction, edge, stance, point), mechanics, category, and stage.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Logic makes magic.
 
 ## How it works
 
-Every move in the library defines an **entry state** (what the skater needs to be doing) and an **exit state** (what the skater ends up doing). The combo generator chains moves by matching exit states to entry states, producing sequences that flow naturally.
+Every move in the library defines an **entry state** (what the skater needs to be doing) and an **exit state** (what the skater ends up doing). The combo generator chains moves by matching exit states to entry states across all four physical dimensions (direction, edge, stance, weight point), producing sequences that flow naturally.
+
+Matching uses a three-tier cascade: it prefers a fully continuous link (direction + point + edge + stance), falls back to matching direction + point, then to direction alone — so it never dead-ends. Each trick reports how continuous its link is via a `transition` field (`start`, `linked`, `edge_shift`, or `reset`), so the output is honest about where the skater makes an implicit adjustment.
 
 The move library (`moves.json`) contains 64 move variants across 7 categories:
 
@@ -64,7 +66,7 @@ for trick in combo:
 # Back Lion (Open): back → front
 ```
 
-Each trick dict contains `id`, `name`, `category`, `stage`, `entry` and `exit` state objects.
+Each trick dict contains `id`, `name`, `category`, `stage`, a `transition` annotation describing its link to the previous trick (`start`/`linked`/`edge_shift`/`reset`), and `entry`/`exit` state objects. The `exit` object includes `direction`, `edge`, `stance`, `point`, plus `lead_foot` and `feet`.
 
 ### JavaScript usage
 

--- a/docs/moves_research.md
+++ b/docs/moves_research.md
@@ -107,14 +107,17 @@ Exit states use relative values (`same`, `opposite`) resolved against the entry:
 
 ## 7. Resolved Design Decisions
 
-### 7a. Dead-ends → Two-tier matching
+### 7a. Dead-ends → Three-tier matching
 
-The generator uses two-tier candidate matching to guarantee `generate_combo(N)` always returns exactly N tricks:
+The generator uses a three-tier candidate cascade to maximize physical continuity while guaranteeing `generate_combo(N)` always returns exactly N tricks:
 
-1. **Strict** (preferred): next move's entry direction AND point must match current exit state
-2. **Relaxed** (fallback): next move's entry direction must match current exit direction
+1. **Strict** (preferred): next move's entry direction, point, **edge AND stance** all match the current exit state — a fully continuous link, no body reset required.
+2. **Mid** (fallback): next move's entry direction and point match; the skater re-sets an edge/stance between tricks.
+3. **Relaxed** (last resort): next move's entry direction matches; the skater also re-distributes weight (point).
 
-The relaxed tier represents implicit state shifts (edge/point adjustments) that skaters naturally perform between tricks. This preserves direction continuity while avoiding dead-ends.
+Direction is the one hard invariant and is preserved by every tier. The lower tiers represent implicit state shifts that skaters naturally perform between tricks, so the generator never dead-ends.
+
+Each emitted trick carries a `transition` field recording which kind of link it required: `start` (first trick), `linked` (strict — full continuity), `edge_shift` (mid), or `reset` (relaxed). This keeps the output honest: a generated combo no longer silently contradicts itself, and consumers can see exactly where an implicit adjustment is expected. In practice ~85% of links achieve full (`linked`) continuity; on those links edge/stance/point/direction never contradict between adjacent tricks (verified by `tests/simulate_continuity.py` and `test_strict_links_are_fully_continuous`).
 
 ### 7b. Two-footed edge → Leading-foot convention
 

--- a/docs/moves_research.md
+++ b/docs/moves_research.md
@@ -109,7 +109,7 @@ Exit states use relative values (`same`, `opposite`) resolved against the entry:
 
 ### 7a. Dead-ends → Three-tier matching
 
-The generator uses a three-tier candidate cascade to maximize physical continuity while guaranteeing `generate_combo(N)` always returns exactly N tricks:
+The generator uses a three-tier candidate cascade to maximize physical continuity while still returning N tricks whenever a direction-compatible continuation exists (always true for the current library; if none did, the generator returns the partial combo rather than dead-ending):
 
 1. **Strict** (preferred): next move's entry direction, point, **edge AND stance** all match the current exit state — a fully continuous link, no body reset required.
 2. **Mid** (fallback): next move's entry direction and point match; the skater re-sets an edge/stance between tricks.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,7 +143,9 @@ combo.forEach(trick => {
 The `generate_combo` function chains tricks using physical state continuity:
 
 1.  The first trick is chosen at random from all moves at or below the specified stage.
-2.  For each subsequent trick, the function uses two-tier matching:
-    *   **Strict**: the next move's entry direction AND weight point must match the current exit state.
-    *   **Relaxed** (fallback): only entry direction must match (implicit edge/point shift between tricks).
-3.  This guarantees the function always returns exactly N tricks with no dead-ends.
+2.  For each subsequent trick, the function uses a three-tier cascade, preferring the most continuous link and widening only when needed:
+    *   **Strict**: the next move's entry direction, weight point, edge AND stance all match the current exit state — a fully continuous link.
+    *   **Mid** (fallback): entry direction and weight point match; the skater re-sets an edge/stance between tricks.
+    *   **Relaxed** (last resort): only entry direction matches; the skater also re-distributes weight (point).
+3.  Each emitted trick carries a `transition` annotation (`start`/`linked`/`edge_shift`/`reset`) recording which tier its link required.
+4.  Direction is the one hard invariant preserved by every tier, so the function returns exactly N tricks as long as a direction-compatible move exists (always true for the current library); if none does, it returns the partial combo built so far rather than dead-ending.

--- a/src/wzrdbrain/wzrdbrain.js
+++ b/src/wzrdbrain/wzrdbrain.js
@@ -43,6 +43,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "center", "stance": "neutral", "point": "toe" },
       "exit": { "direction": "same", "edge": "same", "stance": "same", "point": "toe", "lead_foot": "same", "feet": 1 }
     },
+
     {
       "id": "parallel_turn_o",
       "name": "Parallel Turn (Open)",
@@ -79,6 +80,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "front", "edge": "inside", "stance": "closed", "point": "heel" },
       "exit": { "direction": "same", "edge": "same", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 1 }
     },
+
     {
       "id": "gazelle_f_o",
       "name": "Front Gazelle (Open)",
@@ -116,6 +118,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "inside", "stance": "closed", "point": "toe" },
       "exit": { "direction": "opposite", "edge": "opposite", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 2 }
     },
+
     {
       "id": "gazelle_s_f_o",
       "name": "Front Gazelle S (Open)",
@@ -153,6 +156,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "inside", "stance": "closed", "point": "toe" },
       "exit": { "direction": "opposite", "edge": "opposite", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 2 }
     },
+
     {
       "id": "lion_f_o",
       "name": "Front Lion (Open)",
@@ -189,6 +193,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "outside", "stance": "closed", "point": "toe" },
       "exit": { "direction": "opposite", "edge": "opposite", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 1 }
     },
+
     {
       "id": "lion_s_f_o",
       "name": "Front Lion S (Open)",
@@ -225,6 +230,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "outside", "stance": "closed", "point": "toe" },
       "exit": { "direction": "opposite", "edge": "opposite", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 1 }
     },
+
     {
       "id": "toe_pivot_f_o",
       "name": "Front Toe Pivot (Open)",
@@ -297,6 +303,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "center", "stance": "closed", "point": "heel" },
       "exit": { "direction": "opposite", "edge": "same", "stance": "same", "point": "heel", "lead_foot": "opposite", "feet": 1 }
     },
+
     {
       "id": "stunami_f",
       "name": "Front Stunami",
@@ -335,6 +342,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "inside", "stance": "closed", "point": "toe" },
       "exit": { "direction": "same", "edge": "same", "stance": "same", "point": "toe", "lead_foot": "same", "feet": 2 }
     },
+
     {
       "id": "toe_press_f",
       "name": "Front Toe Press",
@@ -407,6 +415,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "center", "stance": "neutral", "point": "heel" },
       "exit": { "direction": "same", "edge": "same", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 2 }
     },
+
     {
       "id": "spin_180_f",
       "name": "Front 180",
@@ -461,6 +470,7 @@ const MOVE_LIBRARY = {
       "entry": { "direction": "back", "edge": "center", "stance": "neutral", "point": "toe" },
       "exit": { "direction": "opposite", "edge": "same", "stance": "same", "point": "heel", "lead_foot": "same", "feet": 2 }
     },
+
     {
       "id": "parallel_slide_f",
       "name": "Front Parallel Slide",
@@ -593,19 +603,21 @@ const MOVE_LIBRARY = {
 const MOVES = Object.fromEntries(MOVE_LIBRARY.moves.map(m => [m.id, m]));
 
 /**
- * Represents a single trick, resolving its entry and exit states
- * based on the base move definition.
- * @class
+ * Represents a single trick with its direction, stance, and move.
+ * Resolves entry and exit states based on the move definition.
  */
 export class Trick {
   /**
-   * @param {string} moveId The unique identifier for the move.
+   * @param {string} moveId - The unique identifier for the move.
    */
   constructor(moveId) {
     const move = MOVES[moveId];
     if (!move) throw new Error(`Invalid move ID: ${moveId}`);
 
     this.moveId = moveId;
+    this.name = move.name;
+    this.category = move.category;
+    this.stage = move.stage;
 
     // Entry states are absolute in the library
     this.direction = move.entry.direction;
@@ -613,21 +625,23 @@ export class Trick {
     this.stance = move.entry.stance;
     this.point = move.entry.point;
 
-    // Resolve Exit States from relative values
+    // Resolve Exit States
     this.exitDirection = this._resolveRelative(move.exit.direction, this.direction);
     this.exitEdge = this._resolveRelative(move.exit.edge, this.edge);
     this.exitStance = this._resolveRelative(move.exit.stance, this.stance);
-    this.exitPoint = move.exit.point;
+    this.exitPoint = move.exit.point; // Point is always absolute
+    // lead_foot is a relative token (same/opposite) telling the skater whether the
+    // guiding foot switches; feet (1 or 2) is absolute. Both are surfaced in toObject.
     this.exitLeadFoot = move.exit.lead_foot;
     this.exitFeet = move.exit.feet;
   }
 
   /**
-   * Resolves relative state values like "same" or "opposite".
+   * Resolves relative state values (same/opposite).
    * @private
-   * @param {string} value The relative value (e.g., "same", "opposite").
-   * @param {string} base The base value to compare against (e.g., "front").
-   * @returns {string} The resolved, absolute state value.
+   * @param {string} value - The relative value ('same', 'opposite', or an absolute value).
+   * @param {string} base - The base value to compare against.
+   * @returns {string} The resolved absolute value.
    */
   _resolveRelative(value, base) {
     if (value === "same") return base;
@@ -646,23 +660,23 @@ export class Trick {
   }
 
   /**
-   * @returns {string} The human-readable name of the trick's move.
+   * @returns {string} The human-readable name of the trick.
    */
   toString() {
-    return MOVES[this.moveId].name;
+    return this.name;
   }
 
   /**
-   * @param {string} [transition="start"] How this trick links to the previous one.
-   * @returns {object} A plain object representation of the trick.
+   * Returns a plain object representation of the trick.
+   * @param {string} [transition="start"] - How this trick links to the previous one.
+   * @returns {object} Plain object representation of the trick.
    */
   toObject(transition = "start") {
-    const move = MOVES[this.moveId];
     return {
       id: this.moveId,
-      name: move.name,
-      category: move.category,
-      stage: move.stage,
+      name: this.name,
+      category: this.category,
+      stage: this.stage,
       transition: transition,
       entry: {
         direction: this.direction,
@@ -683,27 +697,26 @@ export class Trick {
 }
 
 /**
- * Applies realism constraints to a list of candidate moves.
- * If hardCategory is true and diversity cannot be satisfied, it returns an
- * empty array to signal the caller to try a wider candidate pool.
+ * Applies realism constraints to candidate moves.
+ * If hardCategory is true and category diversity cannot be satisfied,
+ * returns an empty array to signal the caller to try a wider candidate pool.
+ * If hardCategory is false, applies other constraints even if the category repeats.
  * @private
- * @param {object[]} candidates - Array of move objects to filter.
- * @param {Trick[]} combo - The list of tricks already in the combination.
- * @param {boolean} [hardCategory=true] - If true, strictly enforces category diversity.
- * @returns {object[]} The filtered list of candidate moves.
+ * @param {object[]} candidates - Array of move objects.
+ * @param {Trick[]} combo - Tricks selected so far.
+ * @param {boolean} [hardCategory=true] - Whether to enforce strict category diversity.
+ * @returns {object[]} Filtered candidates.
  */
 function _applyRealismFilters(candidates, combo, hardCategory = true) {
-  if (!candidates || candidates.length === 0 || !combo || combo.length === 0) {
-    return candidates;
-  }
+  if (candidates.length === 0 || combo.length === 0) return candidates;
 
   const lastMove = MOVES[combo[combo.length - 1].moveId];
   let filtered = candidates;
 
   // Constraint 1: Max 2 consecutive same category (general)
   if (combo.length >= 2) {
-    const prevMove = MOVES[combo[combo.length - 2].moveId];
-    if (prevMove.category === lastMove.category && lastMove.category !== "slide") {
+    const prevCategory = MOVES[combo[combo.length - 2].moveId].category;
+    if (prevCategory === lastMove.category && lastMove.category !== "slide") {
       const noCat = filtered.filter(m => m.category !== lastMove.category);
       if (noCat.length === 0 && hardCategory) return [];
       if (noCat.length > 0) filtered = noCat;
@@ -712,12 +725,12 @@ function _applyRealismFilters(candidates, combo, hardCategory = true) {
 
   // Constraint 1b: Specific slide probability
   if (lastMove.category === "slide") {
-    // Hard cap at 2 consecutive slides
+    // Hard cap at 2 slides (absolute, ignores hardCategory flag)
     if (combo.length >= 2 && MOVES[combo[combo.length - 2].moveId].category === "slide") {
       const noSlide = filtered.filter(m => m.category !== "slide");
       return noSlide.length > 0 ? noSlide : []; // Absolute hard cap
     } else {
-      // 10% chance to allow a second consecutive slide
+      // 10% chance to allow consecutive slides
       if (Math.random() > 0.10) {
         const noSlide = filtered.filter(m => m.category !== "slide");
         if (noSlide.length === 0 && hardCategory) return [];
@@ -728,46 +741,47 @@ function _applyRealismFilters(candidates, combo, hardCategory = true) {
 
   // Constraint 2: No consecutive same move
   const noDup = filtered.filter(m => m.id !== lastMove.id);
-  if (noDup.length > 0) {
-    filtered = noDup;
-  }
+  if (noDup.length > 0) filtered = noDup;
 
   // Constraint 3: No consecutive high-rotation (degrees >= 360)
   if (lastMove.mechanics.degrees >= 360) {
     const noSpin = filtered.filter(m => m.mechanics.degrees < 360);
-    if (noSpin.length > 0) {
-      filtered = noSpin;
-    }
+    if (noSpin.length > 0) filtered = noSpin;
   }
 
   return filtered;
 }
 
 /**
- * Classifies the physical continuity of a transition between two tricks.
+ * Classifies how physically continuous the link from prev (exit state) into
+ * nxt (entry requirements) is.
  * @private
- * @param {Trick} prev - The previous trick instance.
- * @param {object} nxt - The next move object from the library.
- * @returns {string} The transition type: "linked", "edge_shift", or "reset".
+ * @param {Trick} prev - The previous trick object.
+ * @param {object} nxt - The next move object.
+ * @returns {string} The transition type ("linked", "edge_shift", or "reset").
  */
 function _transitionType(prev, nxt) {
   const edgeOk = nxt.entry.edge === prev.exitEdge;
   const stanceOk = nxt.entry.stance === prev.exitStance;
   const pointOk = nxt.entry.point === prev.exitPoint;
 
-  if (edgeOk && stanceOk && pointOk) return "linked";
-  if (pointOk) return "edge_shift";
+  if (edgeOk && stanceOk && pointOk) {
+    return "linked";
+  }
+  if (pointOk) {
+    return "edge_shift";
+  }
   return "reset";
 }
 
 /**
  * Generates a combination of tricks based on physical state transitions.
- * Candidate selection uses a three-tier cascade to prefer full physical
- * continuity but widens the search to prevent dead-ends.
+ * Candidate selection uses a three-tier cascade so that each link prefers full
+ * physical continuity but never dead-ends.
  *
- * @param {number|null} [numTricks=null] - The number of tricks to generate (2-5 if null).
- * @param {number} [maxStage=5] - The maximum skill stage of moves to include.
- * @returns {object[]} An array of trick objects representing the generated combo.
+ * @param {number|null} [numTricks=null] - Number of tricks to generate (default: 2-5).
+ * @param {number} [maxStage=5] - Maximum skill stage of moves to include.
+ * @returns {object[]} A list of trick objects representing the combo.
  */
 export function generateCombo(numTricks = null, maxStage = 5) {
   if (numTricks === null) {
@@ -780,64 +794,74 @@ export function generateCombo(numTricks = null, maxStage = 5) {
 
   const combo = [];
   const transitions = ["start"];
-  const validMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
-
-  if (validMoves.length === 0) {
-    return [];
-  }
 
   // 1. Select the first trick
-  const firstMove = validMoves[Math.floor(Math.random() * validMoves.length)];
+  const validStartMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
+  if (validStartMoves.length === 0) {
+    return [];
+  }
+  const firstMove = validStartMoves[Math.floor(Math.random() * validStartMoves.length)];
   let currentTrick = new Trick(firstMove.id);
   combo.push(currentTrick);
 
   // 2. Iteratively find compatible moves using the three-tier cascade
   for (let i = 0; i < numTricks - 1; i++) {
-    const eligible = validMoves;
+    const eligible = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
 
     // All tiers preserve direction (the one hard physical invariant).
     const sameDirection = eligible.filter(m => m.entry.direction === currentTrick.exitDirection);
 
-    // Tier 1 (strict): direction + point + edge + stance match.
+    // Tier 1 — strict: direction + point + edge + stance all match the exit state.
     const strict = sameDirection.filter(m =>
       m.entry.point === currentTrick.exitPoint &&
       m.entry.edge === currentTrick.exitEdge &&
       m.entry.stance === currentTrick.exitStance
     );
 
-    // Tier 2 (mid): direction + point match.
+    // Tier 2 — mid: direction + point match (edge/stance re-set between tricks).
     const mid = sameDirection.filter(m => m.entry.point === currentTrick.exitPoint);
 
-    // Tier 3 (relaxed): direction only.
+    // Tier 3 — relaxed: direction only (weight point also re-set).
     const relaxed = sameDirection;
 
-    // Apply realism constraints, widening the pool as needed.
+    // Apply realism constraints to the narrowest pool first, widening as needed.
     const lastId = currentTrick.moveId;
     let candidates = [];
+    let foundCandidates = false;
+
     for (const pool of [strict, mid, relaxed]) {
       const filtered = pool.length > 0 ? _applyRealismFilters(pool, combo, true) : [];
       const nonDup = filtered.filter(m => m.id !== lastId);
       if (nonDup.length > 0) {
         candidates = nonDup;
+        foundCandidates = true;
         break;
       }
     }
 
-    if (candidates.length === 0) {
-      // If all hard-category pools failed, relax the category constraint.
+    if (!foundCandidates) {
+      // Every hard-category pool came up empty; relax the category constraint.
       const filtered = _applyRealismFilters(relaxed, combo, false);
       const nonDup = filtered.filter(m => m.id !== lastId);
       candidates = nonDup.length > 0 ? nonDup : filtered;
     }
 
     if (candidates.length === 0) {
-      // Absolute worst-case fallback: ignore realism filters.
-      const nonDup = relaxed.filter(m => m.id !== lastId);
-      candidates = nonDup.length > 0 ? nonDup : relaxed;
+      // Absolute worst-case fallback, should rarely be hit.
+      // Prefer a non-repeat, but keep the 2-slide hard cap absolute even here.
+      let tempCandidates = relaxed.filter(m => m.id !== lastId);
+      candidates = tempCandidates.length > 0 ? tempCandidates : relaxed;
+      if (
+        combo.length >= 2 &&
+        MOVES[combo[combo.length - 1].moveId].category === "slide" &&
+        MOVES[combo[combo.length - 2].moveId].category === "slide"
+      ) {
+        candidates = candidates.filter(m => m.category !== "slide");
+      }
     }
 
     if (candidates.length === 0) {
-      // No physically valid continuation exists; return the partial combo.
+      // No physically valid continuation exists; return the partial combo
       break;
     }
 

--- a/src/wzrdbrain/wzrdbrain.js
+++ b/src/wzrdbrain/wzrdbrain.js
@@ -593,11 +593,13 @@ const MOVE_LIBRARY = {
 const MOVES = Object.fromEntries(MOVE_LIBRARY.moves.map(m => [m.id, m]));
 
 /**
- * Represents a single trick, resolving its entry and exit states based on the move definition.
+ * Represents a single trick, resolving its entry and exit states
+ * based on the base move definition.
+ * @class
  */
 export class Trick {
   /**
-   * @param {string} moveId - The unique identifier for the move from the move library.
+   * @param {string} moveId The unique identifier for the move.
    */
   constructor(moveId) {
     const move = MOVES[moveId];
@@ -605,30 +607,30 @@ export class Trick {
 
     this.moveId = moveId;
 
-    // Entry states
+    // Entry states are absolute in the library
     this.direction = move.entry.direction;
     this.edge = move.entry.edge;
     this.stance = move.entry.stance;
     this.point = move.entry.point;
 
-    // Resolve Exit States
+    // Resolve Exit States from relative values
     this.exitDirection = this._resolveRelative(move.exit.direction, this.direction);
     this.exitEdge = this._resolveRelative(move.exit.edge, this.edge);
     this.exitStance = this._resolveRelative(move.exit.stance, this.stance);
-    this.exitPoint = move.exit.point; // Point is always absolute
+    this.exitPoint = move.exit.point;
+    this.exitLeadFoot = move.exit.lead_foot;
+    this.exitFeet = move.exit.feet;
   }
 
   /**
-   * Resolves relative state values like "same" or "opposite" into absolute states.
+   * Resolves relative state values like "same" or "opposite".
    * @private
-   * @param {string} value - The relative value (e.g., "same", "opposite").
-   * @param {string} base - The base state to compare against (e.g., "front", "inside").
-   * @returns {string} The resolved absolute state.
+   * @param {string} value The relative value (e.g., "same", "opposite").
+   * @param {string} base The base value to compare against (e.g., "front").
+   * @returns {string} The resolved, absolute state value.
    */
   _resolveRelative(value, base) {
-    if (value === "same") {
-      return base;
-    }
+    if (value === "same") return base;
     if (value === "opposite") {
       const opposites = {
         front: "back",
@@ -651,15 +653,17 @@ export class Trick {
   }
 
   /**
-   * @returns {object} A plain object representation of the trick with its resolved states.
+   * @param {string} [transition="start"] How this trick links to the previous one.
+   * @returns {object} A plain object representation of the trick.
    */
-  toObject() {
+  toObject(transition = "start") {
     const move = MOVES[this.moveId];
     return {
       id: this.moveId,
       name: move.name,
       category: move.category,
       stage: move.stage,
+      transition: transition,
       entry: {
         direction: this.direction,
         edge: this.edge,
@@ -671,6 +675,8 @@ export class Trick {
         edge: this.exitEdge,
         stance: this.exitStance,
         point: this.exitPoint,
+        lead_foot: this.exitLeadFoot,
+        feet: this.exitFeet,
       },
     };
   }
@@ -678,17 +684,16 @@ export class Trick {
 
 /**
  * Applies realism constraints to a list of candidate moves.
- * If hardCategory is true and category diversity cannot be satisfied, it returns
- * an empty array to signal the caller to try a wider candidate pool. If
- * hardCategory is false, it applies other constraints even if the category repeats.
+ * If hardCategory is true and diversity cannot be satisfied, it returns an
+ * empty array to signal the caller to try a wider candidate pool.
  * @private
- * @param {object[]} candidates - An array of move objects to be filtered.
- * @param {Trick[]} combo - The list of tricks already in the combo.
- * @param {boolean} [hardCategory=true] - Whether to enforce strict category diversity.
+ * @param {object[]} candidates - Array of move objects to filter.
+ * @param {Trick[]} combo - The list of tricks already in the combination.
+ * @param {boolean} [hardCategory=true] - If true, strictly enforces category diversity.
  * @returns {object[]} The filtered list of candidate moves.
  */
 function _applyRealismFilters(candidates, combo, hardCategory = true) {
-  if (candidates.length === 0 || combo.length === 0) {
+  if (!candidates || candidates.length === 0 || !combo || combo.length === 0) {
     return candidates;
   }
 
@@ -697,34 +702,26 @@ function _applyRealismFilters(candidates, combo, hardCategory = true) {
 
   // Constraint 1: Max 2 consecutive same category (general)
   if (combo.length >= 2) {
-    const prevCategory = MOVES[combo[combo.length - 2].moveId].category;
-    if (prevCategory === lastMove.category && lastMove.category !== "slide") {
+    const prevMove = MOVES[combo[combo.length - 2].moveId];
+    if (prevMove.category === lastMove.category && lastMove.category !== "slide") {
       const noCat = filtered.filter(m => m.category !== lastMove.category);
-      if (noCat.length === 0 && hardCategory) {
-        return [];
-      }
-      if (noCat.length > 0) {
-        filtered = noCat;
-      }
+      if (noCat.length === 0 && hardCategory) return [];
+      if (noCat.length > 0) filtered = noCat;
     }
   }
 
   // Constraint 1b: Specific slide probability
   if (lastMove.category === "slide") {
-    // Hard cap at 2 slides (absolute, ignores hardCategory flag)
+    // Hard cap at 2 consecutive slides
     if (combo.length >= 2 && MOVES[combo[combo.length - 2].moveId].category === "slide") {
       const noSlide = filtered.filter(m => m.category !== "slide");
-      return noSlide; // Absolute hard cap, never soft-fallback into slides
+      return noSlide.length > 0 ? noSlide : []; // Absolute hard cap
     } else {
-      // 90% chance to force a non-slide after one slide
+      // 10% chance to allow a second consecutive slide
       if (Math.random() > 0.10) {
         const noSlide = filtered.filter(m => m.category !== "slide");
-        if (noSlide.length === 0 && hardCategory) {
-          return [];
-        }
-        if (noSlide.length > 0) {
-          filtered = noSlide;
-        }
+        if (noSlide.length === 0 && hardCategory) return [];
+        if (noSlide.length > 0) filtered = noSlide;
       }
     }
   }
@@ -747,10 +744,28 @@ function _applyRealismFilters(candidates, combo, hardCategory = true) {
 }
 
 /**
- * Generates a combination of tricks based on physical state transitions, ensuring
- * that the exit state of one trick is a valid entry state for the next.
+ * Classifies the physical continuity of a transition between two tricks.
+ * @private
+ * @param {Trick} prev - The previous trick instance.
+ * @param {object} nxt - The next move object from the library.
+ * @returns {string} The transition type: "linked", "edge_shift", or "reset".
+ */
+function _transitionType(prev, nxt) {
+  const edgeOk = nxt.entry.edge === prev.exitEdge;
+  const stanceOk = nxt.entry.stance === prev.exitStance;
+  const pointOk = nxt.entry.point === prev.exitPoint;
+
+  if (edgeOk && stanceOk && pointOk) return "linked";
+  if (pointOk) return "edge_shift";
+  return "reset";
+}
+
+/**
+ * Generates a combination of tricks based on physical state transitions.
+ * Candidate selection uses a three-tier cascade to prefer full physical
+ * continuity but widens the search to prevent dead-ends.
  *
- * @param {number|null} [numTricks=null] - The number of tricks to generate. If null, a random number between 2 and 5 is chosen.
+ * @param {number|null} [numTricks=null] - The number of tricks to generate (2-5 if null).
  * @param {number} [maxStage=5] - The maximum skill stage of moves to include.
  * @returns {object[]} An array of trick objects representing the generated combo.
  */
@@ -764,64 +779,73 @@ export function generateCombo(numTricks = null, maxStage = 5) {
   }
 
   const combo = [];
+  const transitions = ["start"];
+  const validMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
 
-  // 1. Select the first trick uniformly from all moves within max_stage
-  const validStartMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
-  if (validStartMoves.length === 0) {
+  if (validMoves.length === 0) {
     return [];
   }
-  const firstMove = validStartMoves[Math.floor(Math.random() * validStartMoves.length)];
+
+  // 1. Select the first trick
+  const firstMove = validMoves[Math.floor(Math.random() * validMoves.length)];
   let currentTrick = new Trick(firstMove.id);
   combo.push(currentTrick);
 
-  // 2. Iteratively find compatible moves using two-tier matching
+  // 2. Iteratively find compatible moves using the three-tier cascade
   for (let i = 0; i < numTricks - 1; i++) {
-    const eligible = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
+    const eligible = validMoves;
 
-    // Tier 1 — strict: direction + point must both match the current exit state
-    const strict = eligible.filter(m =>
-      m.entry.direction === currentTrick.exitDirection &&
-      m.entry.point === currentTrick.exitPoint
+    // All tiers preserve direction (the one hard physical invariant).
+    const sameDirection = eligible.filter(m => m.entry.direction === currentTrick.exitDirection);
+
+    // Tier 1 (strict): direction + point + edge + stance match.
+    const strict = sameDirection.filter(m =>
+      m.entry.point === currentTrick.exitPoint &&
+      m.entry.edge === currentTrick.exitEdge &&
+      m.entry.stance === currentTrick.exitStance
     );
 
-    // Tier 2 — relaxed: direction only (implicit edge/point shift between tricks)
-    const relaxed = eligible.filter(m => m.entry.direction === currentTrick.exitDirection);
+    // Tier 2 (mid): direction + point match.
+    const mid = sameDirection.filter(m => m.entry.point === currentTrick.exitPoint);
 
-    // Apply realism constraints to strict pool first, widen to relaxed if needed
-    const strictFiltered = strict.length > 0 ? _applyRealismFilters(strict, combo, true) : [];
-    const relaxedFiltered = _applyRealismFilters(relaxed, combo, true);
+    // Tier 3 (relaxed): direction only.
+    const relaxed = sameDirection;
 
-    let candidates;
-    if (strictFiltered.length > 0) {
-      candidates = strictFiltered;
-    } else if (relaxedFiltered.length > 0) {
-      candidates = relaxedFiltered;
-    } else {
-      candidates = _applyRealismFilters(relaxed, combo, false);
-    }
-
-    if (candidates.length === 0) {
-      // Absolute worst-case fallback, should rarely be hit.
-      candidates = relaxed;
-      // Even here, the 2-slide hard cap must be enforced.
-      if (
-        combo.length >= 2 &&
-        MOVES[combo[combo.length - 1].moveId].category === "slide" &&
-        MOVES[combo[combo.length - 2].moveId].category === "slide"
-      ) {
-        candidates = candidates.filter(m => m.category !== "slide");
+    // Apply realism constraints, widening the pool as needed.
+    const lastId = currentTrick.moveId;
+    let candidates = [];
+    for (const pool of [strict, mid, relaxed]) {
+      const filtered = pool.length > 0 ? _applyRealismFilters(pool, combo, true) : [];
+      const nonDup = filtered.filter(m => m.id !== lastId);
+      if (nonDup.length > 0) {
+        candidates = nonDup;
+        break;
       }
     }
 
     if (candidates.length === 0) {
-      // No physically valid continuation exists; return the partial combo
+      // If all hard-category pools failed, relax the category constraint.
+      const filtered = _applyRealismFilters(relaxed, combo, false);
+      const nonDup = filtered.filter(m => m.id !== lastId);
+      candidates = nonDup.length > 0 ? nonDup : filtered;
+    }
+
+    if (candidates.length === 0) {
+      // Absolute worst-case fallback: ignore realism filters.
+      const nonDup = relaxed.filter(m => m.id !== lastId);
+      candidates = nonDup.length > 0 ? nonDup : relaxed;
+    }
+
+    if (candidates.length === 0) {
+      // No physically valid continuation exists; return the partial combo.
       break;
     }
 
     const nextMove = candidates[Math.floor(Math.random() * candidates.length)];
+    transitions.push(_transitionType(currentTrick, nextMove));
     currentTrick = new Trick(nextMove.id);
     combo.push(currentTrick);
   }
 
-  return combo.map(t => t.toObject());
+  return combo.map((t, idx) => t.toObject(transitions[idx]));
 }

--- a/src/wzrdbrain/wzrdbrain.py
+++ b/src/wzrdbrain/wzrdbrain.py
@@ -76,6 +76,8 @@ class Trick:
     exit_edge: str = field(init=False)
     exit_stance: str = field(init=False)
     exit_point: str = field(init=False)
+    exit_lead_foot: str = field(init=False)
+    exit_feet: int = field(init=False)
 
     def __post_init__(self) -> None:
         move = MOVES[self.move_id]
@@ -90,6 +92,10 @@ class Trick:
         self.exit_edge = self._resolve_relative(move.exit.edge, self.edge)
         self.exit_stance = self._resolve_relative(move.exit.stance, self.stance)
         self.exit_point = move.exit.point  # Point is always absolute
+        # lead_foot is a relative token (same/opposite) telling the skater whether the
+        # guiding foot switches; feet (1 or 2) is absolute. Both are surfaced in to_dict.
+        self.exit_lead_foot = move.exit.lead_foot
+        self.exit_feet = move.exit.feet
 
     def _resolve_relative(self, value: str, base: str) -> str:
         if value == "same":
@@ -109,13 +115,17 @@ class Trick:
     def __str__(self) -> str:
         return MOVES[self.move_id].name
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, transition: str = "start") -> dict[str, Any]:
         move = MOVES[self.move_id]
         return {
             "id": self.move_id,
             "name": move.name,
             "category": move.category,
             "stage": move.stage,
+            # How this trick links to the previous one. "start" for the first trick;
+            # otherwise describes how much implicit body adjustment the link required
+            # (see _transition_type).
+            "transition": transition,
             "entry": {
                 "direction": self.direction,
                 "edge": self.edge,
@@ -127,6 +137,8 @@ class Trick:
                 "edge": self.exit_edge,
                 "stance": self.exit_stance,
                 "point": self.exit_point,
+                "lead_foot": self.exit_lead_foot,
+                "feet": self.exit_feet,
             },
         }
 
@@ -188,9 +200,40 @@ def _apply_realism_filters(
     return filtered
 
 
+def _transition_type(prev: Trick, nxt: Move) -> str:
+    """
+    Classifies how physically continuous the link from ``prev`` (exit state) into
+    ``nxt`` (entry requirements) is. The generator always preserves direction, so
+    direction is assumed to match here. Returns, from most to least continuous:
+
+    - "linked":     edge, stance and point all carry over — no body reset needed.
+    - "edge_shift": point carries over but the skater re-sets an edge/stance.
+    - "reset":      direction only — the skater re-distributes weight (point) and edge.
+    """
+    edge_ok = nxt.entry.edge == prev.exit_edge
+    stance_ok = nxt.entry.stance == prev.exit_stance
+    point_ok = nxt.entry.point == prev.exit_point
+
+    if edge_ok and stance_ok and point_ok:
+        return "linked"
+    if point_ok:
+        return "edge_shift"
+    return "reset"
+
+
 def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> list[dict[str, Any]]:
     """
     Generates a combination of tricks based on physical state transitions.
+
+    Candidate selection uses a three-tier cascade so that each link prefers full
+    physical continuity but never dead-ends:
+
+      Tier 1 (strict):  entry direction + point + edge + stance all match the exit state
+      Tier 2 (mid):     entry direction + point match (edge/stance re-set between tricks)
+      Tier 3 (relaxed): entry direction matches (weight point also re-set)
+
+    Each emitted trick records which kind of link it required via the ``transition``
+    field (see _transition_type), so the output never silently contradicts itself.
     """
     if num_of_tricks is None:
         num_of_tricks = random.randint(2, 5)
@@ -199,6 +242,7 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
         return []
 
     combo: list[Trick] = []
+    transitions: list[str] = ["start"]
 
     # 1. Select the first trick uniformly from all moves within max_stage
     valid_start_moves = [m for m in _LIBRARY.moves if m.stage <= max_stage]
@@ -208,38 +252,48 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
     current_trick = Trick(first_move.id)
     combo.append(current_trick)
 
-    # 2. Iteratively find compatible moves using two-tier matching
+    # 2. Iteratively find compatible moves using the three-tier cascade
     for _ in range(num_of_tricks - 1):
         eligible = [m for m in _LIBRARY.moves if m.stage <= max_stage]
 
-        # Tier 1 — strict: direction + point must both match the current exit state
+        # All tiers preserve direction (the one hard physical invariant).
+        same_direction = [m for m in eligible if m.entry.direction == current_trick.exit_direction]
+
+        # Tier 1 — strict: direction + point + edge + stance all match the exit state.
         strict = [
             m
-            for m in eligible
-            if m.entry.direction == current_trick.exit_direction
-            and m.entry.point == current_trick.exit_point
+            for m in same_direction
+            if m.entry.point == current_trick.exit_point
+            and m.entry.edge == current_trick.exit_edge
+            and m.entry.stance == current_trick.exit_stance
         ]
 
-        # Tier 2 — relaxed: direction only (implicit edge/point shift between tricks)
-        relaxed = [m for m in eligible if m.entry.direction == current_trick.exit_direction]
+        # Tier 2 — mid: direction + point match (edge/stance re-set between tricks).
+        mid = [m for m in same_direction if m.entry.point == current_trick.exit_point]
 
-        # Apply realism constraints to strict pool first, widen to relaxed if needed
-        strict_filtered = (
-            _apply_realism_filters(strict, combo, hard_category=True) if strict else []
-        )
-        relaxed_filtered = _apply_realism_filters(relaxed, combo, hard_category=True)
+        # Tier 3 — relaxed: direction only (weight point also re-set).
+        relaxed = same_direction
 
-        if strict_filtered:
-            candidates = strict_filtered
-        elif relaxed_filtered:
-            candidates = relaxed_filtered
+        # Apply realism constraints to the narrowest pool first, widening as needed.
+        # A tier is only accepted if it offers a move other than an immediate repeat;
+        # otherwise we widen so a single same-move survivor never forces a duplicate.
+        last_id = current_trick.move_id
+        candidates = []
+        for pool in (strict, mid, relaxed):
+            filtered = _apply_realism_filters(pool, combo, hard_category=True) if pool else []
+            non_dup = [m for m in filtered if m.id != last_id]
+            if non_dup:
+                candidates = non_dup
+                break
         else:
-            candidates = _apply_realism_filters(relaxed, combo, hard_category=False)
+            # Every hard-category pool came up empty; relax the category constraint.
+            filtered = _apply_realism_filters(relaxed, combo, hard_category=False)
+            candidates = [m for m in filtered if m.id != last_id] or filtered
 
         if not candidates:
             # Absolute worst-case fallback, should rarely be hit given the library size.
-            # Even here the 2-slide hard cap is absolute and must hold.
-            candidates = relaxed
+            # Prefer a non-repeat, but keep the 2-slide hard cap absolute even here.
+            candidates = [m for m in relaxed if m.id != last_id] or relaxed
             if (
                 len(combo) >= 2
                 and MOVES[combo[-1].move_id].category == "slide"
@@ -252,7 +306,8 @@ def generate_combo(num_of_tricks: Optional[int] = None, max_stage: int = 5) -> l
             break
 
         next_move = random.choice(candidates)
+        transitions.append(_transition_type(current_trick, next_move))
         current_trick = Trick(next_move.id)
         combo.append(current_trick)
 
-    return [t.to_dict() for t in combo]
+    return [t.to_dict(transition) for t, transition in zip(combo, transitions)]

--- a/tests/show_examples.py
+++ b/tests/show_examples.py
@@ -1,0 +1,56 @@
+"""
+Prints a handful of example combos from wzrdbrain's combo generator, showing the
+physical state flow (direction/edge/stance/point) and the ``transition`` annotation
+on every link.
+
+This is a demo/inspection script, not a pytest module — run it directly:
+
+    ./venv/bin/python tests/show_examples.py [--count N] [--length L] [--seed S]
+
+Link markers:
+    ●  start       first trick in the combo
+    =  linked      edge + stance + point all carry over (fully continuous)
+    ~  edge_shift  point carries over; the skater re-sets an edge/stance
+    !  reset       direction only; the skater also re-distributes weight (point)
+"""
+
+import argparse
+import random
+
+from wzrdbrain.wzrdbrain import generate_combo
+
+MARKER = {"start": "●", "linked": "=", "edge_shift": "~", "reset": "!"}
+
+
+def _state(s: dict[str, str]) -> str:
+    return f"{s['direction']}/{s['edge']}/{s['stance']}/{s['point']}"
+
+
+def show(count: int, length: int, seed: int) -> None:
+    random.seed(seed)
+    print(f"{count} example combos x {length} tricks (seed {seed})")
+    print("markers:  ● start   = linked   ~ edge_shift   ! reset")
+    print()
+    for n in range(1, count + 1):
+        combo = generate_combo(length)
+        print(f"Combo {n}:")
+        for trick in combo:
+            marker = MARKER[trick["transition"]]
+            flow = f"{_state(trick['entry']):>24} -> {_state(trick['exit'])}"
+            print(f"  {marker} {trick['name']:<26} [{trick['category']:<10}] {flow}")
+        links = " ".join(t["transition"] for t in combo[1:])
+        print(f"    links: {links}")
+        print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--count", type=int, default=5, help="number of combos to print")
+    parser.add_argument("--length", type=int, default=4, help="tricks per combo")
+    parser.add_argument("--seed", type=int, default=7, help="RNG seed for reproducibility")
+    args = parser.parse_args()
+    show(args.count, args.length, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/simulate_continuity.py
+++ b/tests/simulate_continuity.py
@@ -1,0 +1,94 @@
+"""
+Physical-continuity simulation for wzrdbrain's combo generator.
+
+Generates many combos and measures, across every adjacent trick pair, how often the
+previous trick's exit state contradicts the next trick's entry requirement on each
+physical dimension (direction / edge / stance / point). It also reports the
+distribution of the ``transition`` annotation the generator attaches to each link.
+
+This is a diagnostic/reporting script, not a pytest module — run it directly:
+
+    ./venv/bin/python tests/simulate_continuity.py [--combos N] [--length L] [--seed S]
+
+The companion assertion-based guarantees live in test_wzrdbrain.py
+(test_strict_links_are_fully_continuous, test_strict_links_dominate).
+"""
+
+import argparse
+import random
+from collections import Counter
+from dataclasses import dataclass, field
+
+from wzrdbrain.wzrdbrain import generate_combo
+
+DIMENSIONS = ("direction", "edge", "stance", "point")
+
+
+@dataclass
+class SimulationResult:
+    total_pairs: int = 0
+    mismatches: dict[str, int] = field(default_factory=lambda: {d: 0 for d in DIMENSIONS})
+    transitions: Counter[str] = field(default_factory=Counter)
+    strict_pairs: int = 0
+    strict_mismatches: dict[str, int] = field(default_factory=lambda: {d: 0 for d in DIMENSIONS})
+
+
+def run(num_combos: int, length: int, seed: int) -> SimulationResult:
+    random.seed(seed)
+    result = SimulationResult()
+
+    for _ in range(num_combos):
+        combo = generate_combo(length)
+        for trick in combo:
+            result.transitions[trick["transition"]] += 1
+        for current, nxt in zip(combo, combo[1:]):
+            result.total_pairs += 1
+            is_strict = nxt["transition"] == "linked"
+            if is_strict:
+                result.strict_pairs += 1
+            for dim in DIMENSIONS:
+                if current["exit"][dim] != nxt["entry"][dim]:
+                    result.mismatches[dim] += 1
+                    if is_strict:
+                        result.strict_mismatches[dim] += 1
+
+    return result
+
+
+def _pct(n: int, d: int) -> str:
+    return f"{(100 * n / d):.1f}%" if d else "n/a"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--combos", type=int, default=2000, help="number of combos to generate")
+    parser.add_argument("--length", type=int, default=5, help="tricks per combo")
+    parser.add_argument("--seed", type=int, default=42, help="RNG seed for reproducibility")
+    args = parser.parse_args()
+
+    result = run(args.combos, args.length, args.seed)
+    total = result.total_pairs
+
+    print(f"combos={args.combos} length={args.length} seed={args.seed}")
+    print(f"adjacent trick pairs: {total}")
+    print()
+    print("=== mismatches across ALL links (any tier) ===")
+    for dim in DIMENSIONS:
+        c = result.mismatches[dim]
+        print(f"  {dim:10s}: {c:6d} ({_pct(c, total)})")
+    print()
+    print("=== transition annotation distribution ===")
+    grand = sum(result.transitions.values())
+    for label, c in result.transitions.most_common():
+        print(f"  {label:10s}: {c:6d} ({_pct(c, grand)})")
+    print()
+    strict_pairs = result.strict_pairs
+    print("=== mismatches on 'linked' (strict) links only — should be 0 ===")
+    print(f"  strict links: {strict_pairs} ({_pct(strict_pairs, total)} of all links)")
+    for dim in DIMENSIONS:
+        c = result.strict_mismatches[dim]
+        print(f"  {dim:10s}: {c:6d} ({_pct(c, strict_pairs)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wzrdbrain.py
+++ b/tests/test_wzrdbrain.py
@@ -70,6 +70,64 @@ def test_generate_combo_physical_continuity() -> None:
             assert current["exit"]["direction"] == next_trick["entry"]["direction"]
 
 
+def test_strict_links_are_fully_continuous() -> None:
+    """
+    Links annotated "linked" must carry over every physical dimension (direction,
+    edge, stance, point) with no contradiction between the previous exit state and
+    the next entry requirement.
+    """
+    for _ in range(100):
+        combo = generate_combo(5)
+        for current, nxt in zip(combo, combo[1:]):
+            if nxt["transition"] != "linked":
+                continue
+            for dim in ("direction", "edge", "stance", "point"):
+                assert current["exit"][dim] == nxt["entry"][dim], (
+                    f"'linked' transition into {nxt['name']} broke {dim}: "
+                    f"{current['exit'][dim]} -> {nxt['entry'][dim]}"
+                )
+
+
+def test_strict_links_dominate() -> None:
+    """
+    Most links should achieve full ('linked') continuity. The tiered cascade only
+    falls back to edge_shift/reset when no fully-continuous candidate survives the
+    realism filters, which should be the minority case across many combos.
+    """
+    linked = 0
+    non_start = 0
+    for _ in range(200):
+        combo = generate_combo(5)
+        for trick in combo:
+            if trick["transition"] == "start":
+                continue
+            non_start += 1
+            if trick["transition"] == "linked":
+                linked += 1
+    assert non_start > 0
+    assert linked / non_start > 0.5, f"Only {linked}/{non_start} links were fully continuous"
+
+
+def test_transition_field_values() -> None:
+    """Every trick exposes a transition annotation; the first is always 'start'."""
+    valid = {"start", "linked", "edge_shift", "reset"}
+    for _ in range(20):
+        combo = generate_combo(4)
+        assert combo[0]["transition"] == "start"
+        for trick in combo:
+            assert trick["transition"] in valid
+
+
+def test_to_dict_surfaces_lead_foot_and_feet() -> None:
+    """Exit state must surface lead_foot and feet so downstream consumers see them."""
+    trick_dict = Trick("lion_f_o").to_dict()
+    assert "lead_foot" in trick_dict["exit"]
+    assert "feet" in trick_dict["exit"]
+    # lion_f_o is a one-footed move
+    assert trick_dict["exit"]["feet"] == MOVES["lion_f_o"].exit.feet
+    assert trick_dict["exit"]["lead_foot"] == MOVES["lion_f_o"].exit.lead_foot
+
+
 def test_generate_combo_stage_filtering() -> None:
     """Test that max_stage correctly filters moves."""
     combo = generate_combo(5, max_stage=1)

--- a/utils/translate2js.py
+++ b/utils/translate2js.py
@@ -63,7 +63,7 @@ You are an expert Python to JavaScript translator. Your task is to translate the
     *   Implement a `toObject()` method equivalent to the Python `to_dict()` method.
 7.  **Function Translation:**
     *   Translate the `generate_combo` Python function into a `generateCombo` JavaScript function.
-    *   Ensure the logic for generating subsequent tricks uses the physical state continuity logic (Direction and Weight Point matching), just like the Python implementation.
+    *   Ensure the logic for generating subsequent tricks uses the physical state continuity logic (the three-tier matching cascade), just like the Python implementation.
 8.  **Code Style & Comments:**
     *   Maintain clean, readable code consistent with the reference file.
     *   Include JSDoc comments for the exported class and function, explaining what they do, their parameters, and what they return.

--- a/utils/wzrdbrain.base.js
+++ b/utils/wzrdbrain.base.js
@@ -41,6 +41,10 @@ export class Trick {
     this.exitEdge = this._resolveRelative(move.exit.edge, this.edge);
     this.exitStance = this._resolveRelative(move.exit.stance, this.stance);
     this.exitPoint = move.exit.point; // Point is always absolute
+    // lead_foot is a relative token (same/opposite) telling the skater whether the
+    // guiding foot switches; feet (1 or 2) is absolute. Both are surfaced in toObject.
+    this.exitLeadFoot = move.exit.lead_foot;
+    this.exitFeet = move.exit.feet;
   }
 
   /**
@@ -71,14 +75,16 @@ export class Trick {
   }
 
   /**
+   * @param {string} [transition="start"] - How this trick links to the previous one.
    * @returns {object} Plain object representation of the trick.
    */
-  toObject() {
+  toObject(transition = "start") {
     return {
       id: this.moveId,
       name: this.name,
       category: this.category,
       stage: this.stage,
+      transition: transition,
       entry: {
         direction: this.direction,
         edge: this.edge,
@@ -90,6 +96,8 @@ export class Trick {
         edge: this.exitEdge,
         stance: this.exitStance,
         point: this.exitPoint,
+        lead_foot: this.exitLeadFoot,
+        feet: this.exitFeet,
       },
     };
   }
@@ -152,6 +160,28 @@ function _applyRealismFilters(candidates, combo, hardCategory = true) {
 }
 
 /**
+ * Classifies how physically continuous the link from prev (exit state) into
+ * nxt (entry requirements) is.
+ * @private
+ * @param {Trick} prev - The previous trick.
+ * @param {object} nxt - The next move object.
+ * @returns {string} The transition type ("linked", "edge_shift", or "reset").
+ */
+function _transitionType(prev, nxt) {
+  const edgeOk = nxt.entry.edge === prev.exitEdge;
+  const stanceOk = nxt.entry.stance === prev.exitStance;
+  const pointOk = nxt.entry.point === prev.exitPoint;
+
+  if (edgeOk && stanceOk && pointOk) {
+    return "linked";
+  }
+  if (pointOk) {
+    return "edge_shift";
+  }
+  return "reset";
+}
+
+/**
  * Generates a combination of tricks based on physical state transitions.
  *
  * @param {number|null} [numTricks=null] - Number of tricks to generate.
@@ -163,57 +193,83 @@ export function generateCombo(numTricks = null, maxStage = 5) {
     numTricks = Math.floor(Math.random() * (5 - 2 + 1)) + 2;
   }
 
-  if (numTricks <= 0) return [];
+  if (numTricks <= 0) {
+    return [];
+  }
 
   const combo = [];
+  const transitions = ["start"];
   const validMoves = MOVE_LIBRARY.moves.filter(m => m.stage <= maxStage);
 
-  if (validMoves.length === 0) return [];
+  if (validMoves.length === 0) {
+    return [];
+  }
 
   // 1. Select the first trick
-  let currentMove = validMoves[Math.floor(Math.random() * validMoves.length)];
-  let currentTrick = new Trick(currentMove.id);
+  const firstMove = validMoves[Math.floor(Math.random() * validMoves.length)];
+  let currentTrick = new Trick(firstMove.id);
   combo.push(currentTrick);
 
-  // 2. Iteratively find compatible moves using two-tier matching
+  // 2. Iteratively find compatible moves using the three-tier cascade
   for (let i = 0; i < numTricks - 1; i++) {
-    // Tier 1 — strict: direction + point must both match the current exit state
-    const strictCandidates = validMoves.filter(m =>
-      m.entry.direction === currentTrick.exitDirection &&
-      m.entry.point === currentTrick.exitPoint
+    const eligible = validMoves;
+
+    // All tiers preserve direction (the one hard physical invariant).
+    const sameDirection = eligible.filter(m => m.entry.direction === currentTrick.exitDirection);
+
+    // Tier 1 — strict: direction + point + edge + stance all match the exit state.
+    const strict = sameDirection.filter(m =>
+      m.entry.point === currentTrick.exitPoint &&
+      m.entry.edge === currentTrick.exitEdge &&
+      m.entry.stance === currentTrick.exitStance
     );
 
-    // Tier 2 — relaxed: direction only (implicit edge/point shift between tricks)
-    const relaxedCandidates = validMoves.filter(m =>
-      m.entry.direction === currentTrick.exitDirection
-    );
+    // Tier 2 — mid: direction + point match (edge/stance re-set between tricks).
+    const mid = sameDirection.filter(m => m.entry.point === currentTrick.exitPoint);
 
-    if (relaxedCandidates.length === 0) break; // Should theoretically not happen with a complete library
+    // Tier 3 — relaxed: direction only (weight point also re-set).
+    const relaxed = sameDirection;
 
-    // Apply realism constraints with tiered fallback
-    const strictFiltered = strictCandidates.length > 0 ? _applyRealismFilters(strictCandidates, combo, true) : [];
-    const relaxedFiltered = _applyRealismFilters(relaxedCandidates, combo, true);
+    // Apply realism constraints to the narrowest pool first, widening as needed.
+    // A tier is only accepted if it offers a move other than an immediate repeat;
+    // otherwise we widen so a single same-move survivor never forces a duplicate.
+    const lastId = currentTrick.moveId;
+    let candidates = [];
 
-    let candidates;
-    if (strictFiltered.length > 0) {
-      candidates = strictFiltered;
-    } else if (relaxedFiltered.length > 0) {
-      candidates = relaxedFiltered;
-    } else {
-      // Soft fallback: relax category enforcement but keep dedup and spin limits
-      candidates = _applyRealismFilters(relaxedCandidates, combo, false);
+    for (const pool of [strict, mid, pool => relaxed]) {
+      // If pool is a function, evaluate it, otherwise use it directly
+      const currentPool = typeof pool === "function" ? pool() : pool;
+      const filtered = currentPool.length > 0 ? _applyRealismFilters(currentPool, combo, true) : [];
+      const nonDup = filtered.filter(m => m.id !== lastId);
+      if (nonDup.length > 0) {
+        candidates = nonDup;
+        break;
+      }
     }
 
     if (candidates.length === 0) {
-      // Absolute worst-case fallback
-      candidates = relaxedCandidates;
-      if (candidates.length === 0) break;
+      // Every hard-category pool came up empty; relax the category constraint.
+      const filtered = _applyRealismFilters(relaxed, combo, false);
+      const nonDup = filtered.filter(m => m.id !== lastId);
+      candidates = nonDup.length > 0 ? nonDup : filtered;
+    }
+
+    if (candidates.length === 0) {
+      // Absolute worst-case fallback, should rarely be hit given the library size.
+      const nonDup = relaxed.filter(m => m.id !== lastId);
+      candidates = nonDup.length > 0 ? nonDup : relaxed;
+    }
+
+    if (candidates.length === 0) {
+      // No physically valid continuation exists; return the partial combo
+      break;
     }
 
     const nextMove = candidates[Math.floor(Math.random() * candidates.length)];
+    transitions.push(_transitionType(currentTrick, nextMove));
     currentTrick = new Trick(nextMove.id);
     combo.push(currentTrick);
   }
 
-  return combo.map(t => t.toObject());
+  return combo.map((t, idx) => t.toObject(transitions[idx]));
 }

--- a/utils/wzrdbrain.base.js
+++ b/utils/wzrdbrain.base.js
@@ -236,10 +236,8 @@ export function generateCombo(numTricks = null, maxStage = 5) {
     const lastId = currentTrick.moveId;
     let candidates = [];
 
-    for (const pool of [strict, mid, pool => relaxed]) {
-      // If pool is a function, evaluate it, otherwise use it directly
-      const currentPool = typeof pool === "function" ? pool() : pool;
-      const filtered = currentPool.length > 0 ? _applyRealismFilters(currentPool, combo, true) : [];
+    for (const pool of [strict, mid, relaxed]) {
+      const filtered = pool.length > 0 ? _applyRealismFilters(pool, combo, true) : [];
       const nonDup = filtered.filter(m => m.id !== lastId);
       if (nonDup.length > 0) {
         candidates = nonDup;


### PR DESCRIPTION
## Context

The README calls wzrdbrain a "physics-aware combo generator … so generated combinations are actually executable." A review found the implementation only enforced **half** of that: `generate_combo` matched on direction (always) and point (preferred), but `edge` and `stance` were resolved, stored, and emitted in the output **yet never used to constrain move selection**. Adjacent tricks contradicted each other ~57% (edge) and ~69% (stance) of the time.

## What changed

- **Three-tier matching cascade** in `generate_combo`: strict (direction + point + **edge + stance**) → mid (direction + point) → relaxed (direction only). Direction stays the one hard invariant; tiers widen only when needed, so combos never dead-end.
- **Honest `transition` annotation** on every emitted trick (`start` / `linked` / `edge_shift` / `reset`) via a new `_transition_type` helper — the output now says where an implicit body adjustment is expected instead of silently contradicting itself.
- **Surfaced previously-dead fields**: `exit.lead_foot` and `exit.feet` were parsed by Pydantic but never reached `to_dict`; they're now resolved on `Trick` and included.
- **Fixed a latent consecutive-duplicate case** the narrower strict tier exposed: a tier is accepted only if it offers a non-repeat move.

## Results

Measured over 5,000 × 5-trick combos (same seed), old vs. new:

| Metric | Old | New | Change |
|---|---:|---:|---:|
| Direction mismatch | 0.0% | 0.0% | unchanged (invariant) |
| Edge mismatch | 57.2% | 7.0% | ↓ 50.2 pp |
| Stance mismatch | 68.5% | 12.1% | ↓ 56.4 pp |
| Point mismatch | 5.6% | 5.8% | ↑ 0.2 pp (noise) |
| Fully-continuous links | 16.7% | 84.5% | ↑ 67.8 pp |

On links tagged `linked` (84.5%), mismatch is **0%** across all four dimensions. The residual edge/stance % is entirely on links now explicitly labeled `edge_shift`/`reset`.

## Tests & tooling

- New assertions in `tests/test_wzrdbrain.py`: `test_strict_links_are_fully_continuous`, `test_strict_links_dominate`, `test_transition_field_values`, `test_to_dict_surfaces_lead_foot_and_feet`.
- `tests/simulate_continuity.py` — runnable continuity report.
- `tests/show_examples.py` — runnable annotated example combos.
- Docs updated from "two-tier" to the three-tier model (`README.md`, `AGENTS.md`, `docs/moves_research.md`).

All CI gates pass locally: ruff, black, mypy --strict, 31 pytest tests.

> Note: `wzrdbrain.js` is auto-generated by CI from the Python source, so it is intentionally not hand-edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)