### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wzrdbrain"
-version = "0.4.1"
+version = "0.5.0"
 description = "A simple library to generate trick combinations and moves for wizard style inline skating."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/wzrdbrain/__init__.py
+++ b/src/wzrdbrain/__init__.py
@@ -6,4 +6,4 @@ from .wzrdbrain import generate_combo
 
 __all__ = ["generate_combo"]
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"


### PR DESCRIPTION
Minor version bump for the 0.5.0 release: breaking removal of the JavaScript port (#46) plus the edge/stance-aware combo generation (#45) and back-entry turns (#46).

Version locations updated: `pyproject.toml`, `src/wzrdbrain/__init__.py`. The `v0.4.1` JSDelivr URL in README is the frozen legacy pin and is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)