### PR TITLE
chore: repo hygiene — gitignore log CSVs, pin pydantic>=2, files() API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist/
 htmlcov/
 .ruff_cache/
 venv/
+
+# Log dumps
+logs_*.csv
 # macOS
 .DS_Store
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"
 dependencies = [
-    "pydantic"
+    "pydantic>=2"
 ]
 authors = [
   { name = "nazroll" }

--- a/src/wzrdbrain/wzrdbrain.py
+++ b/src/wzrdbrain/wzrdbrain.py
@@ -55,7 +55,7 @@ class MoveLibrary(BaseModel):
 # Load move library from JSON
 def _load_move_library() -> MoveLibrary:
     """Loads move definitions from the embedded moves.json file."""
-    with importlib.resources.open_text("wzrdbrain", "moves.json") as f:
+    with importlib.resources.files("wzrdbrain").joinpath("moves.json").open(encoding="utf-8") as f:
         data = json.load(f)
         return MoveLibrary.model_validate(data)
 


### PR DESCRIPTION
## Summary
- Add `logs_*.csv` to `.gitignore` (preventative — the stray log CSV that motivated #43 is already gone)
- Pin `pydantic>=2` in `pyproject.toml`: the code already requires the v2 API (`model_validate`), so an environment resolving pydantic v1 fails at import today; this makes the requirement explicit
- Replace deprecated `importlib.resources.open_text` with the `files()` API (deprecated since Python 3.11; `files()` is available from 3.9, matching `requires-python`)

The third #43 item (misleading first-trick comment) was already fixed on main (`wzrdbrain.py:247`).

Closes #42
Closes #43

## Test plan
- `ruff check .`, `black --check .`, `mypy .` (strict), `pytest` — all green locally (37 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)