### PR TITLE
feat: enforce move schema at load time with Literal enums

### DIFF
--- a/src/wzrdbrain/wzrdbrain.py
+++ b/src/wzrdbrain/wzrdbrain.py
@@ -1,9 +1,22 @@
 import random
 import json
 import importlib.resources
-from typing import Optional, Any
+from typing import Optional, Any, Literal
 from dataclasses import dataclass, field
 from pydantic import BaseModel, Field
+
+# Enums mirroring move_schema.json. Entry states are absolute; exit states may
+# also be the relative tokens "same"/"opposite", resolved against the entry.
+EntryDirection = Literal["front", "back"]
+ExitDirection = Literal["same", "opposite", "front", "back"]
+EntryEdge = Literal["inside", "outside", "center"]
+ExitEdge = Literal["same", "opposite", "inside", "outside", "center"]
+EntryStance = Literal["open", "closed", "neutral"]
+ExitStance = Literal["same", "opposite", "open", "closed", "neutral"]
+Point = Literal["toe", "heel", "all", "none"]
+LeadFoot = Literal["same", "opposite"]
+Category = Literal["base", "turn", "transition", "manual", "pivot", "slide", "swivel", "air"]
+RotationType = Literal["natural", "switch", "neutral"]
 
 
 # Pydantic models for the new state-transition schema
@@ -11,22 +24,22 @@ class Mechanics(BaseModel):
     feet: int
     is_rotation: bool
     degrees: int
-    rotation_type: str
+    rotation_type: RotationType
 
 
 class State(BaseModel):
-    direction: str
-    edge: str
-    stance: str
-    point: str
+    direction: EntryDirection
+    edge: EntryEdge
+    stance: EntryStance
+    point: Point
 
 
 class ExitState(BaseModel):
-    direction: str
-    edge: str
-    stance: str
-    point: str
-    lead_foot: str
+    direction: ExitDirection
+    edge: ExitEdge
+    stance: ExitStance
+    point: Point
+    lead_foot: LeadFoot
     feet: int
 
 
@@ -39,7 +52,7 @@ class Metadata(BaseModel):
 class Move(BaseModel):
     id: str
     name: str
-    category: str
+    category: Category
     stage: int
     mechanics: Mechanics
     entry: State

--- a/tests/test_wzrdbrain.py
+++ b/tests/test_wzrdbrain.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import pytest
+from pydantic import ValidationError
 
 import wzrdbrain.wzrdbrain as wzrdbrain_module
 from wzrdbrain.wzrdbrain import (
@@ -306,6 +309,45 @@ def test_all_moves_in_library_are_valid() -> None:
         assert move.entry.stance in valid_stances, f"{move.id}: bad entry stance"
         assert move.entry.point in valid_points, f"{move.id}: bad entry point"
         assert 1 <= move.stage <= 5, f"{move.id}: bad stage {move.stage}"
+
+
+def test_invalid_enum_values_rejected_at_load() -> None:
+    """MoveLibrary should reject moves with values outside the schema enums."""
+    valid_move: dict[str, Any] = {
+        "id": "test_move",
+        "name": "Test Move",
+        "category": "base",
+        "stage": 1,
+        "mechanics": {"feet": 2, "is_rotation": False, "degrees": 0, "rotation_type": "neutral"},
+        "entry": {"direction": "front", "edge": "center", "stance": "neutral", "point": "all"},
+        "exit": {
+            "direction": "same",
+            "edge": "same",
+            "stance": "same",
+            "point": "all",
+            "lead_foot": "same",
+            "feet": 2,
+        },
+    }
+    # Sanity check: the valid move loads
+    MoveLibrary.model_validate({"version": "test", "moves": [valid_move]})
+
+    bad_cases = [
+        ("entry", {"direction": "fornt"}),  # typo
+        ("entry", {"edge": "sideways"}),
+        ("entry", {"point": "ball"}),
+        ("exit", {"direction": "reverse"}),
+        ("exit", {"lead_foot": "front"}),  # absolute value not allowed for lead_foot
+    ]
+    for section, override in bad_cases:
+        bad_move: dict[str, Any] = {**valid_move, section: {**valid_move[section], **override}}
+        with pytest.raises(ValidationError):
+            MoveLibrary.model_validate({"version": "test", "moves": [bad_move]})
+
+    for top_override in [{"category": "dance"}]:
+        bad_move = {**valid_move, **top_override}
+        with pytest.raises(ValidationError):
+            MoveLibrary.model_validate({"version": "test", "moves": [bad_move]})
 
 
 def test_combo_variety() -> None:


### PR DESCRIPTION
## Summary
- Replace `str` fields in the pydantic models (`State`, `ExitState`, `Mechanics.rotation_type`, `Move.category`) with `Literal` types mirroring `move_schema.json`'s enums exactly, so `_load_move_library()` rejects bad data at import
- Entry vs exit get **distinct** Literal types: entry values are absolute, exit values may also be relative (`same`/`opposite`) plus absolute overrides — the flat Literals proposed in the issue text would have rejected every move in the library
- Typed to the schema's full enums (includes `air`, `switch`, `none`) rather than only the values currently observed in `moves.json`, so valid future data doesn't break
- New test `test_invalid_enum_values_rejected_at_load` covers typo'd direction/edge/point, invalid exit tokens, and bad category; the existing `test_all_moves_in_library_are_valid` stays as belt-and-suspenders

Closes #41

## Test plan
- `ruff check .`, `black --check .`, `mypy .` (strict), `pytest` — all green locally (38 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)