### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wzrdbrain"
-version = "0.5.0"
+version = "0.6.0"
 description = "A simple library to generate trick combinations and moves for wizard style inline skating."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/wzrdbrain/__init__.py
+++ b/src/wzrdbrain/__init__.py
@@ -6,4 +6,4 @@ from .wzrdbrain import generate_combo
 
 __all__ = ["generate_combo"]
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
Version bump for the 0.6.0 release, covering #50 (hygiene), #51 (load-time schema enforcement), and #52 (terminology toggle + move data normalization).

Minor bump: new `terminology` API feature; note the move id/name normalization in #52 is breaking for consumers that stored move ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)